### PR TITLE
Add a name for the login option.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==19.3b0
-click==6.7
+click==7.0
 coveralls==1.7.0
 hypothesis==3.69.2
 isort==4.3.16

--- a/zfs/replicate/cli/main.py
+++ b/zfs/replicate/cli/main.py
@@ -20,7 +20,7 @@ from .click import EnumChoice
 )
 @click.option("--recursive", is_flag=True, help="Recursively replicate snapshots.")
 @click.option("--port", "-p", type=click.IntRange(1, 65535), metavar="PORT", default=22, help="Connect to SSH on PORT.")
-@click.option("--login", "-l", "--user", "-u", metavar="USER", help="Connect to SSH as USER.")
+@click.option("--login", "-l", "--user", "-u", "user", metavar="USER", help="Connect to SSH as USER.")
 @click.option(
     "-i",
     "--identity-file",

--- a/zfs_test/replicate_test/cli_test/main_test.py
+++ b/zfs_test/replicate_test/cli_test/main_test.py
@@ -1,0 +1,11 @@
+from click.testing import CliRunner
+
+from zfs.replicate.cli.main import main
+
+
+def test_invokes_without_stacktrace() -> None:
+    """zfs-replicate -l alunduil -i mypy.ini example.com bogus bogus => No stacktrace"""
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["-l", "alunduil", "-i", "mypy.ini", "example.com", "bogus", "bogus"])
+    assert isinstance(result.exception, SystemExit), "Expected normal exit."


### PR DESCRIPTION
It seems that between click 6 and 7 the name of an argument changed to
the longest long option.  The solution is to use an explicit name.  In
addition, I've added a test that ensures if we see any exception other
than a correct SystemExit coming from main (even an error).