### PR TITLE
Add readonly option to required permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Allow user to mount (FreeBSD_)::
 
 ZFS_ Permissions::
 
-    zfs allow <user> create,destroy,snapshot,rollback,clone,promote,rename,mount,send,receive,readonly,quota,reservation,hold <backup_dataset>
+    zfs allow ${USER} create,destroy,snapshot,rollback,clone,promote,rename,mount,send,receive,readonly,quota,reservation,hold ${BACKUP_DATASET}
 
 More information about this configuration can be found at the following sources:
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Allow user to mount (FreeBSD_)::
 
 ZFS_ Permissions::
 
-    zfs allow backup create,destroy,snapshot,rollback,clone,promote,rename,mount,send,receive,quota,reservation,hold storage
+    zfs allow <user> create,destroy,snapshot,rollback,clone,promote,rename,mount,send,receive,readonly,quota,reservation,hold <backup_dataset>
 
 More information about this configuration can be found at the following sources:
 


### PR DESCRIPTION
Thanks for making this project! It works well for simple configurations, however while setting it up using the NixOS module I noticed that a normal user needs the `readonly` permission on a dataset to be able to create readonly sub-datasets.