### PR TITLE
Use the public name of hypothesis's SearchStrategy

### DIFF
--- a/zfs_test/replicate_test/snapshot_test/list_test.py
+++ b/zfs_test/replicate_test/snapshot_test/list_test.py
@@ -4,8 +4,7 @@ import string
 from typing import Any, Dict, List
 
 from hypothesis import given
-from hypothesis.searchstrategy import SearchStrategy
-from hypothesis.strategies import fixed_dictionaries, integers, lists, none, text
+from hypothesis.strategies import SearchStrategy, fixed_dictionaries, integers, lists, none, text
 
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.list import _snapshot, _snapshots


### PR DESCRIPTION
The internal name changed in hypothesis 4.53.2, with a
release note indicating that any references affected
by this ought to be using the public names instead:
https://hypothesis.readthedocs.io/en/latest/changes.html

This is required to build zfs-replicate with versions of hypothesis released after 2019-12-11.