### PR TITLE
Update travis python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
   - "3.6"
-  - "3.6-dev"
-  - "3.7-dev"
+  - "3.7"
+    #- "3.8"
+    #- "3.9-dev"
   - "nightly"
 matrix:
   allow_failures:


### PR DESCRIPTION
We want to remain testing on the most recent versions of python that we
can at all times.