### PR TITLE
Add generate tests found in the Haskell experiment.

### DIFF
--- a/zfs_test/replicate_test/snapshot_test/list_test.py
+++ b/zfs_test/replicate_test/snapshot_test/list_test.py
@@ -1,29 +1,16 @@
 """zfs.replicate.snapshot tests"""
 
-import string
-from typing import Any, Dict, List
+from typing import List
 
 from hypothesis import given
-from hypothesis.strategies import SearchStrategy, fixed_dictionaries, integers, lists, none, text
+from hypothesis.strategies import lists
 
-from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.list import _snapshot, _snapshots
 from zfs.replicate.snapshot.type import Snapshot
-
-NOT_WHITESPACE = [x for x in string.printable if x not in string.whitespace and x != "@"]
-
-filesystems = text(NOT_WHITESPACE).map(filesystem)  # pylint: disable=invalid-name
-
-snapshots_dict: Dict[str, SearchStrategy[Any]] = {
-    "filesystem": filesystems,
-    "name": text(NOT_WHITESPACE),
-    "timestamp": integers(),
-    "previous": none(),
-}
-snapshots = fixed_dictionaries(snapshots_dict).map(lambda kwargs: Snapshot(**kwargs))  # pylint: disable=invalid-name
+from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
-@given(lists(snapshots))
+@given(lists(SNAPSHOTS))
 def test_snapshots(snapshots: List[Snapshot]) -> None:  # pylint: disable=redefined-outer-name
     """_snapshots"""
 
@@ -31,7 +18,15 @@ def test_snapshots(snapshots: List[Snapshot]) -> None:  # pylint: disable=redefi
     assert _snapshots(output.encode()) == snapshots
 
 
-@given(snapshots)
+@given(lists(SNAPSHOTS, min_size=1))
+def test_snapshots_depth(snapshots: List[Snapshot]) -> None:
+    """_snapshots max depth <= 2"""
+
+    output = "\n".join([_output(s) for s in snapshots])
+    assert max(map(_depth, _snapshots(output.encode()))) <= 2
+
+
+@given(SNAPSHOTS)
 def test_snapshot(snapshot: Snapshot) -> None:
     """_snapshot"""
 
@@ -40,3 +35,7 @@ def test_snapshot(snapshot: Snapshot) -> None:
 
 def _output(snapshot: Snapshot) -> str:
     return f"{snapshot.filesystem.name}@{snapshot.name}\t{snapshot.timestamp}"
+
+
+def _depth(snapshot: Snapshot) -> int:
+    return 1 if snapshot.previous is None else 1 + _depth(snapshot.previous)

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -1,0 +1,21 @@
+"""Snapshot Hypothesis Strategies"""
+
+import string
+from typing import Any, Dict
+
+from hypothesis.strategies import SearchStrategy, fixed_dictionaries, integers, none, text
+
+from zfs.replicate.filesystem.type import filesystem
+from zfs.replicate.snapshot.type import Snapshot
+
+_NOT_WHITESPACE = [x for x in string.printable if x not in string.whitespace and x != "@"]
+
+_FILESYSTEMS = text(_NOT_WHITESPACE).map(lambda x: "a{x}").map(filesystem)
+
+_SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
+    "filesystem": _FILESYSTEMS,
+    "name": text(_NOT_WHITESPACE),
+    "timestamp": integers(),
+    "previous": none(),
+}
+SNAPSHOTS = fixed_dictionaries(_SNAPSHOTS_DICT).map(lambda kwargs: Snapshot(**kwargs))

--- a/zfs_test/replicate_test/snapshot_test/type_test.py
+++ b/zfs_test/replicate_test/snapshot_test/type_test.py
@@ -1,0 +1,12 @@
+"""zfs.replicate.snapshot.type tests"""
+
+from zfs.replicate.filesystem.type import filesystem
+from zfs.replicate.snapshot.type import Snapshot
+
+
+def test_eq_ignore_previous() -> None:
+    """Snapshot.previous ignored in eq"""
+
+    zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
+    previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
+    assert zero == previous

--- a/zfs_test/replicate_test/task_test/generate_test.py
+++ b/zfs_test/replicate_test/task_test/generate_test.py
@@ -1,8 +1,54 @@
+import itertools
+import operator
+
+from hypothesis import given
+from hypothesis.strategies import lists
+
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.task.generate import *  # pylint: disable=unused-wildcard-import,wildcard-import
+from zfs.replicate.task.type import Action
+from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
 def test_no_tasks() -> None:
     """generate(Any, {}, {}) == []"""
 
     assert [] == generate(filesystem("pool/filesystem"), {}, {})
+
+
+@given(lists(SNAPSHOTS))
+def test_empty_remotes(snapshots: List[Snapshot]) -> None:
+    """generate with empty remotes"""
+
+    snapshots_by_fs = {
+        k: list(v)
+        for (k, v) in itertools.groupby(
+            sorted(snapshots, key=operator.attrgetter("filesystem")), key=operator.attrgetter("filesystem")
+        )
+    }
+
+    result = generate(filesystem(""), snapshots_by_fs, {})
+
+    assert len([t for t in result if t.action == Action.CREATE and t.snapshot is None]) == len(snapshots_by_fs)
+    assert len([t for t in result if t.action == Action.SEND and t.snapshot is not None]) == sum(
+        map(len, snapshots_by_fs.values())
+    )
+
+
+@given(lists(SNAPSHOTS))
+def test_empty_locals(snapshots: List[Snapshot]) -> None:
+    """generate with empty locals"""
+
+    snapshots_by_fs = {
+        k: list(v)
+        for (k, v) in itertools.groupby(
+            sorted(snapshots, key=operator.attrgetter("filesystem")), key=operator.attrgetter("filesystem")
+        )
+    }
+
+    result = generate(filesystem(""), {}, snapshots_by_fs)
+
+    assert len([t for t in result if t.action == Action.DESTROY]) == len(snapshots_by_fs) + sum(
+        map(len, snapshots_by_fs.values())
+    )
+    assert all(t.action == Action.DESTROY for t in result)


### PR DESCRIPTION
Going through the exercise of converting this project to Haskell showed
some obvious missing test cases.  They're added here to ensure we remain
true as we continue forward with this python version.