### PR TITLE
Ensure that the packagse are installed.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include LICENSE
-include Makefile
 include mypy.ini
 include README.rst
 include setup.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,9 @@
 [metadata]
 name = zfs-replicate
-version = 1.2.0
+version = 1.2.3
 description = ZFS Snapshot Replicator
 long_description = file: README.rst
 long_description_content_type = text/x-rst
-url = "https://github.com/alunduil/zfs-replicate"
 author = Alex Brandt
 author_email = alunduil@gmail.com
 license = BSD-2
@@ -29,7 +28,15 @@ classifiers =
   Topic :: System :: Filesystems
 
 [options]
-packages = find:
+packages =
+  zfs.replicate
+  zfs.replicate.cli
+  zfs.replicate.compress
+  zfs.replicate.filesystem
+  zfs.replicate.snapshot
+  zfs.replicate.ssh
+  zfs.replicate.task
+
 install_requires =
   click
   stringcase


### PR DESCRIPTION
For some reason the new setup doesn't like namespace packages and this
was all kinds of failure.  Now we list the packages manually and things
are happy again.  We'll have to evaluate adding this check to travis
somehow as well.