### PR TITLE
Add --raw to zfs-send options.

### DIFF
--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -53,7 +53,7 @@ def send(  # pylint: disable=R0913
 def _send(
     current: Snapshot, previous: Optional[Snapshot] = None, follow_delete: bool = False
 ) -> str:
-    options = []  # ["-V"]
+    options = ["--raw"]  # ["-V"]
 
     if follow_delete:
         options.append("-p")


### PR DESCRIPTION
Without --raw, encrypted datasets cannot be sent and this tool is effectively
useless for that use case.  This should be backwards compatible but I'll be
bumping the version by a minor due to this change just in case it has unexpected
side effects.

closes #179