### PR TITLE
Update devcontainer configuration.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,8 @@
 ARG VARIANT="3.10-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-RUN su vscode -c "curl -sSL https://install.python-poetry.org | python3 -"
+USER vscode
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3
 {
-	"name": "Python 3",
+	"name": "zfs-replicate",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
@@ -47,6 +47,5 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"git": "os-provided"
 	}
 }


### PR DESCRIPTION
Some minor changes have happened in the VS Code devcontainers configuration.  I
can no longer get this to start with the git feature (even the new replacement
feature).  This allows the environment to start so we can continue making
progress with this project, but a deeper study of devcontainer environments will
be needed at some point.