### PR TITLE
Mark version 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/alunduil/zfs-replicate"
-version = "2.0.0"
+version = "2.1.1"
 
 [tool.poetry.dependencies]
 click = "^8.1.3"


### PR DESCRIPTION
Ensure that the version is in pyproject.toml matches our next release so we can publish a version successfully.