### PR TITLE
Bump version 2.2.1 to 3.0.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/alunduil/zfs-replicate"
-version = "2.2.1"
+version = "3.0.0"
 
 [tool.poetry.dependencies]
 click = "^8.1.3"


### PR DESCRIPTION
Major because we're dropping support for Python 3.7 which changes which
interpreters can be used for this utility.