### PR TITLE
Add nix GitHub workflow.

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,14 @@
+name: "Nix Build"
+on:
+  pull_request:
+  push:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build nix/default.nix --show-trace


### PR DESCRIPTION
This should highlight issues with nix-build as reported in #207.  This also
means we get on push reproductions that we can verify correctness before
releases.