### PR TITLE
docs: document Conventional Commits dialect for contributors and agents (#424)

### DIFF
--- a/.github/copilot/commit-message.instructions.md
+++ b/.github/copilot/commit-message.instructions.md
@@ -1,0 +1,193 @@
+# Commit message conventions
+
+zfs-replicate uses [Conventional Commits](https://www.conventionalcommits.org/) so that
+the CI commit-lint check passes on the first try and `release-please` places each
+commit in the right section of the CHANGELOG and applies the correct semver bump.
+
+This file is the single source of truth for the repo's dialect.
+
+## The seven rules
+
+These come from [Tim Pope's well-known note on git commit messages](https://cbea.ms/git-commit/):
+
+1. **Separate subject from body with a blank line.**
+2. **Limit the subject line to 50 characters.** Hard target; lint may flag at 72.
+3. **Capitalize the subject line.** The first letter after `type(scope):` is lower-case;
+   capitalize the first word of the description.
+4. **Do not end the subject line with a period.**
+5. **Use the imperative mood in the subject line.** `add`, `fix`, `remove` — not
+   `added`, `fixes`, `removing`. The convention is "if applied, this commit will
+   _\<subject\>_".
+6. **Wrap the body at 72 characters.**
+7. **Use the body to explain _what_ and _why_ vs _how_.** The diff already shows _how_.
+
+## Subject format
+
+```
+<type>[optional scope][!]: <description>
+```
+
+A breaking-change marker (`!`) immediately before the colon causes `release-please` to
+issue a major-version bump regardless of `<type>`.
+
+## Allowed types
+
+| Type       | When to use it                                                     | release-please bump | Example                                                              |
+| ---------- | ------------------------------------------------------------------ | ------------------- | -------------------------------------------------------------------- |
+| `feat`     | New user-visible functionality                                     | minor               | `feat(send): support --resume for interrupted snapshots`             |
+| `fix`      | Bug fix                                                            | patch               | `fix(executor): close ssh transport on early exit`                   |
+| `perf`     | Performance improvement with no functional change                  | patch               | `perf(send): pipeline mbuffer between local and remote zfs`          |
+| `refactor` | Internal change with no functional or performance impact           | none                | `refactor(cli): extract argument parsing into its own module`        |
+| `docs`     | Documentation only                                                 | none                | `docs: clarify --recursive flag in README`                           |
+| `test`     | Adding or fixing tests                                             | none                | `test(executor): cover the timeout-vs-cancel branch`                 |
+| `build`    | Build system, packaging, or dependency updates (poetry, nix, etc.) | none                | `build(deps): bump cryptography to 44.0.1`                           |
+| `ci`       | CI configuration                                                   | none                | `ci: run pytest on Python 3.13`                                      |
+| `chore`    | Maintenance with no source impact (release notes, etc.)            | none                | `chore: regenerate CHANGELOG`                                        |
+| `revert`   | Revert of a previous commit                                        | matches reverted    | `revert: feat(send): support --resume for interrupted snapshots`     |
+
+A commit that introduces a breaking change uses the type that best describes the change
+and adds the `!` marker, regardless of which bump that type would normally produce.
+
+## Scope policy
+
+Scope is **optional**. When the change is bounded to one module, use the module name in
+parentheses. The scopes in active use right now:
+
+- `send` — `zfs/send.py` and adjacent send-pipeline code
+- `cli` — argparse plumbing and entry points
+- `executor` — subprocess / SSH wrappers
+- `ci` — anything under `.github/workflows/`
+- `docs` — README, CONTRIBUTING, this file
+- `deps` — paired with `build:` for dependency bumps (`build(deps): ...`)
+
+Add new scopes when they earn it — a one-off touch in a module is not a new scope.
+
+## Breaking changes
+
+Two ways to mark a breaking change. **Both** must appear; the marker without the footer
+is easy to miss in code review.
+
+1. The `!` marker in the subject:
+
+   ```
+   feat(cli)!: rename --hosts to --targets
+   ```
+
+2. A `BREAKING CHANGE:` footer in the body:
+
+   ```
+   BREAKING CHANGE: --hosts has been renamed to --targets to match the rest
+   of the documentation. Update your wrapper scripts.
+   ```
+
+Either type can take `!`. A breaking `fix!` still produces a major bump.
+
+## release-please type → semver bump
+
+`release-please` reads the commit messages on `main` since the last release tag and
+chooses the bump based on the highest-impact commit:
+
+- Any commit with `BREAKING CHANGE:` footer or `!` marker → **major**
+- Otherwise, any `feat:` → **minor**
+- Otherwise, any `fix:` or `perf:` → **patch**
+- Otherwise → no release
+
+`docs`, `test`, `refactor`, `build`, `ci`, `chore`, `revert` (without `!`) do not
+release on their own.
+
+## Examples for each type
+
+These are real changes from this repo, retrofitted to the format. Use them as templates.
+
+```
+feat(send): emit progress over stderr when --progress is set
+
+Wraps the `mbuffer` invocation so callers piping to systemd journal
+get one line per gigabyte instead of a single ETA at the end. Falls
+back to silent transport when --progress is absent so existing cron
+output stays unchanged.
+```
+
+```
+fix(executor): close ssh transport on early exit
+
+When `zfs list` failed before the recv pipeline started, the SSH
+control socket leaked and the next replicate run would fail to
+authenticate against the same host within the cache window. Wrap the
+client construction in a try/finally and close on every exit path.
+```
+
+```
+perf(send): pipeline mbuffer between local and remote zfs
+
+Routing the `zfs send | zfs recv` pair through a 256 MB mbuffer
+smooths the bandwidth curve and shortens replication of a 1.2 TB
+dataset from 41 min to 28 min on the test bench (`pytest -k bench`).
+```
+
+```
+refactor(cli): extract argument parsing into its own module
+
+Pulls the argparse setup out of `__main__.py` into `cli/arguments.py`
+to make the entry point easier to read and to let the CLI be
+exercised without invoking `main()`. No behavior change.
+```
+
+```
+docs: clarify --recursive flag in README
+
+`--recursive` only walks ZFS children, not snapshots — note the
+distinction so users do not assume snapshots are also recursive.
+```
+
+```
+test(executor): cover the timeout-vs-cancel branch
+
+Adds a parametrized test that exercises both the `asyncio.TimeoutError`
+and `asyncio.CancelledError` branches in `Executor.run`, which were
+previously only exercised by the integration suite.
+```
+
+```
+build(deps): bump cryptography to 44.0.1
+
+Pulls in the upstream fix for CVE-2025-12345.
+```
+
+```
+ci: run pytest on Python 3.13
+
+Adds 3.13 to the pytest matrix in `.github/workflows/pytest.yml` and
+drops 3.10 (EOL April 2026).
+```
+
+```
+chore: regenerate CHANGELOG
+
+`release-please` PR for v1.4.0.
+```
+
+```
+revert: feat(send): support --resume for interrupted snapshots
+
+This reverts commit abc1234. Resume mode broke replication when the
+remote dataset already had a partial snapshot from a previous run;
+see #321 for the failure mode. Will re-attempt with a different
+strategy.
+```
+
+```
+feat(cli)!: rename --hosts to --targets
+
+The CLI accepted both --hosts and --targets for the destination
+list; --targets matches the documentation and the option name in
+the underlying executor module. Drop --hosts.
+
+BREAKING CHANGE: --hosts has been renamed to --targets. Wrapper
+scripts and crontabs that pass --hosts must be updated.
+```
+
+## Out of scope for this file
+
+CI enforcement of these conventions is tracked separately. This file teaches; the
+linter (when configured) enforces.

--- a/.github/copilot/commit-message.instructions.md
+++ b/.github/copilot/commit-message.instructions.md
@@ -21,5 +21,5 @@ When generating a commit message, produce this shape:
 - Breaking change: add `!` before the colon **and** a `BREAKING CHANGE:` footer. See
   [CONTRIBUTING.md - Breaking changes](../../CONTRIBUTING.md#breaking-changes).
 
-If the full set of rules or the worked examples are needed, follow the CONTRIBUTING.md
-links above; don't duplicate them here.
+For type definitions, scope guidance, and the breaking-change format, follow the
+CONTRIBUTING.md links above; don't duplicate them here.

--- a/.github/copilot/commit-message.instructions.md
+++ b/.github/copilot/commit-message.instructions.md
@@ -1,193 +1,25 @@
-# Commit message conventions
+# Commit message conventions (AI agents)
 
-zfs-replicate uses [Conventional Commits](https://www.conventionalcommits.org/) so that
-the CI commit-lint check passes on the first try and `release-please` places each
-commit in the right section of the CHANGELOG and applies the correct semver bump.
+Full conventions live in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#commit-messages) -
+that document is the single source of truth for humans and bots alike. Read it first.
 
-This file is the single source of truth for the repo's dialect.
+## Shorthand for AI agents
 
-## The seven rules
-
-These come from [Tim Pope's well-known note on git commit messages](https://cbea.ms/git-commit/):
-
-1. **Separate subject from body with a blank line.**
-2. **Limit the subject line to 50 characters.** Hard target; lint may flag at 72.
-3. **Capitalize the subject line.** The first letter after `type(scope):` is lower-case;
-   capitalize the first word of the description.
-4. **Do not end the subject line with a period.**
-5. **Use the imperative mood in the subject line.** `add`, `fix`, `remove` — not
-   `added`, `fixes`, `removing`. The convention is "if applied, this commit will
-   _\<subject\>_".
-6. **Wrap the body at 72 characters.**
-7. **Use the body to explain _what_ and _why_ vs _how_.** The diff already shows _how_.
-
-## Subject format
+When generating a commit message, produce this shape:
 
 ```
-<type>[optional scope][!]: <description>
+<type>[optional scope][!]: <imperative, <=50 chars, no trailing period>
+
+<body wrapped at 72 chars, explaining what and why>
 ```
 
-A breaking-change marker (`!`) immediately before the colon causes `release-please` to
-issue a major-version bump regardless of `<type>`.
+- `<type>` is one of: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`,
+  `chore`, `revert`. Definitions and `release-please` bumps are in
+  [CONTRIBUTING.md - Allowed types](../../CONTRIBUTING.md#allowed-types).
+- Scope is optional. Active scopes: `send`, `cli`, `executor`, `ci`, `docs`, `deps`.
+  See [CONTRIBUTING.md - Scope policy](../../CONTRIBUTING.md#scope-policy).
+- Breaking change: add `!` before the colon **and** a `BREAKING CHANGE:` footer. See
+  [CONTRIBUTING.md - Breaking changes](../../CONTRIBUTING.md#breaking-changes).
 
-## Allowed types
-
-| Type       | When to use it                                                     | release-please bump | Example                                                              |
-| ---------- | ------------------------------------------------------------------ | ------------------- | -------------------------------------------------------------------- |
-| `feat`     | New user-visible functionality                                     | minor               | `feat(send): support --resume for interrupted snapshots`             |
-| `fix`      | Bug fix                                                            | patch               | `fix(executor): close ssh transport on early exit`                   |
-| `perf`     | Performance improvement with no functional change                  | patch               | `perf(send): pipeline mbuffer between local and remote zfs`          |
-| `refactor` | Internal change with no functional or performance impact           | none                | `refactor(cli): extract argument parsing into its own module`        |
-| `docs`     | Documentation only                                                 | none                | `docs: clarify --recursive flag in README`                           |
-| `test`     | Adding or fixing tests                                             | none                | `test(executor): cover the timeout-vs-cancel branch`                 |
-| `build`    | Build system, packaging, or dependency updates (poetry, nix, etc.) | none                | `build(deps): bump cryptography to 44.0.1`                           |
-| `ci`       | CI configuration                                                   | none                | `ci: run pytest on Python 3.13`                                      |
-| `chore`    | Maintenance with no source impact (release notes, etc.)            | none                | `chore: regenerate CHANGELOG`                                        |
-| `revert`   | Revert of a previous commit                                        | matches reverted    | `revert: feat(send): support --resume for interrupted snapshots`     |
-
-A commit that introduces a breaking change uses the type that best describes the change
-and adds the `!` marker, regardless of which bump that type would normally produce.
-
-## Scope policy
-
-Scope is **optional**. When the change is bounded to one module, use the module name in
-parentheses. The scopes in active use right now:
-
-- `send` — `zfs/send.py` and adjacent send-pipeline code
-- `cli` — argparse plumbing and entry points
-- `executor` — subprocess / SSH wrappers
-- `ci` — anything under `.github/workflows/`
-- `docs` — README, CONTRIBUTING, this file
-- `deps` — paired with `build:` for dependency bumps (`build(deps): ...`)
-
-Add new scopes when they earn it — a one-off touch in a module is not a new scope.
-
-## Breaking changes
-
-Two ways to mark a breaking change. **Both** must appear; the marker without the footer
-is easy to miss in code review.
-
-1. The `!` marker in the subject:
-
-   ```
-   feat(cli)!: rename --hosts to --targets
-   ```
-
-2. A `BREAKING CHANGE:` footer in the body:
-
-   ```
-   BREAKING CHANGE: --hosts has been renamed to --targets to match the rest
-   of the documentation. Update your wrapper scripts.
-   ```
-
-Either type can take `!`. A breaking `fix!` still produces a major bump.
-
-## release-please type → semver bump
-
-`release-please` reads the commit messages on `main` since the last release tag and
-chooses the bump based on the highest-impact commit:
-
-- Any commit with `BREAKING CHANGE:` footer or `!` marker → **major**
-- Otherwise, any `feat:` → **minor**
-- Otherwise, any `fix:` or `perf:` → **patch**
-- Otherwise → no release
-
-`docs`, `test`, `refactor`, `build`, `ci`, `chore`, `revert` (without `!`) do not
-release on their own.
-
-## Examples for each type
-
-These are real changes from this repo, retrofitted to the format. Use them as templates.
-
-```
-feat(send): emit progress over stderr when --progress is set
-
-Wraps the `mbuffer` invocation so callers piping to systemd journal
-get one line per gigabyte instead of a single ETA at the end. Falls
-back to silent transport when --progress is absent so existing cron
-output stays unchanged.
-```
-
-```
-fix(executor): close ssh transport on early exit
-
-When `zfs list` failed before the recv pipeline started, the SSH
-control socket leaked and the next replicate run would fail to
-authenticate against the same host within the cache window. Wrap the
-client construction in a try/finally and close on every exit path.
-```
-
-```
-perf(send): pipeline mbuffer between local and remote zfs
-
-Routing the `zfs send | zfs recv` pair through a 256 MB mbuffer
-smooths the bandwidth curve and shortens replication of a 1.2 TB
-dataset from 41 min to 28 min on the test bench (`pytest -k bench`).
-```
-
-```
-refactor(cli): extract argument parsing into its own module
-
-Pulls the argparse setup out of `__main__.py` into `cli/arguments.py`
-to make the entry point easier to read and to let the CLI be
-exercised without invoking `main()`. No behavior change.
-```
-
-```
-docs: clarify --recursive flag in README
-
-`--recursive` only walks ZFS children, not snapshots — note the
-distinction so users do not assume snapshots are also recursive.
-```
-
-```
-test(executor): cover the timeout-vs-cancel branch
-
-Adds a parametrized test that exercises both the `asyncio.TimeoutError`
-and `asyncio.CancelledError` branches in `Executor.run`, which were
-previously only exercised by the integration suite.
-```
-
-```
-build(deps): bump cryptography to 44.0.1
-
-Pulls in the upstream fix for CVE-2025-12345.
-```
-
-```
-ci: run pytest on Python 3.13
-
-Adds 3.13 to the pytest matrix in `.github/workflows/pytest.yml` and
-drops 3.10 (EOL April 2026).
-```
-
-```
-chore: regenerate CHANGELOG
-
-`release-please` PR for v1.4.0.
-```
-
-```
-revert: feat(send): support --resume for interrupted snapshots
-
-This reverts commit abc1234. Resume mode broke replication when the
-remote dataset already had a partial snapshot from a previous run;
-see #321 for the failure mode. Will re-attempt with a different
-strategy.
-```
-
-```
-feat(cli)!: rename --hosts to --targets
-
-The CLI accepted both --hosts and --targets for the destination
-list; --targets matches the documentation and the option name in
-the underlying executor module. Drop --hosts.
-
-BREAKING CHANGE: --hosts has been renamed to --targets. Wrapper
-scripts and crontabs that pass --hosts must be updated.
-```
-
-## Out of scope for this file
-
-CI enforcement of these conventions is tracked separately. This file teaches; the
-linter (when configured) enforces.
+If the full set of rules or the worked examples are needed, follow the CONTRIBUTING.md
+links above; don't duplicate them here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,21 +100,9 @@ interest in being an owner of this project, ask.
 zfs-replicate uses [Conventional Commits](https://www.conventionalcommits.org/) so that
 the CI commit-lint check passes on the first try and `release-please` places each
 commit in the right section of the CHANGELOG and applies the correct semver bump.
-
-### The seven rules
-
-These come from [Tim Pope's well-known note on git commit messages](https://cbea.ms/git-commit/):
-
-1. **Separate subject from body with a blank line.**
-2. **Limit the subject line to 50 characters.** Hard target; lint may flag at 72.
-3. **Capitalize the subject line.** The first letter after `type(scope):` is lower-case;
-   capitalize the first word of the description.
-4. **Do not end the subject line with a period.**
-5. **Use the imperative mood in the subject line.** `add`, `fix`, `remove` - not
-   `added`, `fixes`, `removing`. The convention is "if applied, this commit will
-   _\<subject\>_".
-6. **Wrap the body at 72 characters.**
-7. **Use the body to explain _what_ and _why_ vs _how_.** The diff already shows _how_.
+Subjects are imperative, capped near 50 characters, no trailing period; bodies wrap at
+72 and explain _what_ and _why_. See [Tim Pope's note on git commit messages](https://cbea.ms/git-commit/)
+for the underlying rules.
 
 ### Subject format
 
@@ -189,103 +177,6 @@ chooses the bump based on the highest-impact commit:
 
 `docs`, `test`, `refactor`, `build`, `ci`, `chore`, `revert` (without `!`) do not
 release on their own.
-
-### Examples for each type
-
-These are real changes from this repo, retrofitted to the format. Use them as templates.
-
-```
-feat(send): emit progress over stderr when --progress is set
-
-Wraps the `mbuffer` invocation so callers piping to systemd journal
-get one line per gigabyte instead of a single ETA at the end. Falls
-back to silent transport when --progress is absent so existing cron
-output stays unchanged.
-```
-
-```
-fix(executor): close ssh transport on early exit
-
-When `zfs list` failed before the recv pipeline started, the SSH
-control socket leaked and the next replicate run would fail to
-authenticate against the same host within the cache window. Wrap the
-client construction in a try/finally and close on every exit path.
-```
-
-```
-perf(send): pipeline mbuffer between local and remote zfs
-
-Routing the `zfs send | zfs recv` pair through a 256 MB mbuffer
-smooths the bandwidth curve and shortens replication of a 1.2 TB
-dataset from 41 min to 28 min on the test bench (`pytest -k bench`).
-```
-
-```
-refactor(cli): extract argument parsing into its own module
-
-Pulls the argparse setup out of `__main__.py` into `cli/arguments.py`
-to make the entry point easier to read and to let the CLI be
-exercised without invoking `main()`. No behavior change.
-```
-
-```
-docs: clarify --recursive flag in README
-
-`--recursive` only walks ZFS children, not snapshots - note the
-distinction so users do not assume snapshots are also recursive.
-```
-
-```
-test(executor): cover the timeout-vs-cancel branch
-
-Adds a parametrized test that exercises both the `asyncio.TimeoutError`
-and `asyncio.CancelledError` branches in `Executor.run`, which were
-previously only exercised by the integration suite.
-```
-
-```
-build(deps): bump cryptography to 44.0.1
-
-Pulls in the upstream fix for CVE-2025-12345.
-```
-
-```
-ci: run pytest on Python 3.13
-
-Adds 3.13 to the pytest matrix in `.github/workflows/pytest.yml` and
-drops 3.10 (EOL April 2026).
-```
-
-```
-chore: regenerate CHANGELOG
-
-`release-please` PR for v1.4.0.
-```
-
-```
-revert: feat(send): support --resume for interrupted snapshots
-
-This reverts commit abc1234. Resume mode broke replication when the
-remote dataset already had a partial snapshot from a previous run;
-see #321 for the failure mode. Will re-attempt with a different
-strategy.
-```
-
-```
-feat(cli)!: rename --hosts to --targets
-
-The CLI accepted both --hosts and --targets for the destination
-list; --targets matches the documentation and the option name in
-the underlying executor module. Drop --hosts.
-
-BREAKING CHANGE: --hosts has been renamed to --targets. Wrapper
-scripts and crontabs that pass --hosts must be updated.
-```
-
-### Out of scope for this file
-
-CI enforcement of these conventions is tracked separately. This file teaches; the
-linter (when configured) enforces.
 
 [First Timers Only]: https://www.firsttimersonly.com/
 [good first issues]: https://github.com/alunduil/zfs-replicate/issues?q=is%3Aissue+label%3A%22good+first+issue%22+is%3Aopen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,8 @@ interest in being an owner of this project, ask.
 ## Commit messages
 
 zfs-replicate uses [Conventional Commits](https://www.conventionalcommits.org/) so that
-the CI commit-lint check passes on the first try and `release-please` places each
-commit in the right section of the CHANGELOG and applies the correct semver bump.
+the CI commit-lint check passes the first time, `release-please` places each commit in
+the right section of the CHANGELOG, and the correct semver bump comes out the other end.
 Subjects are imperative, capped near 50 characters, no trailing period; bodies wrap at
 72 and explain _what_ and _why_. See [Tim Pope's note on git commit messages](https://cbea.ms/git-commit/)
 for the underlying rules.
@@ -117,15 +117,15 @@ issue a major-version bump regardless of `<type>`.
 
 | Type       | When to use it                                                     | release-please bump | Example                                                              |
 | ---------- | ------------------------------------------------------------------ | ------------------- | -------------------------------------------------------------------- |
-| `feat`     | New user-visible functionality                                     | minor               | `feat(send): support --resume for interrupted snapshots`             |
+| `feat`     | New user-visible capability                                        | minor               | `feat(send): support --resume for interrupted snapshots`             |
 | `fix`      | Bug fix                                                            | patch               | `fix(executor): close ssh transport on early exit`                   |
 | `perf`     | Performance improvement with no functional change                  | patch               | `perf(send): pipeline mbuffer between local and remote zfs`          |
 | `refactor` | Internal change with no functional or performance impact           | none                | `refactor(cli): extract argument parsing into its own module`        |
 | `docs`     | Documentation only                                                 | none                | `docs: clarify --recursive flag in README`                           |
 | `test`     | Adding or fixing tests                                             | none                | `test(executor): cover the timeout-vs-cancel branch`                 |
-| `build`    | Build system, packaging, or dependency updates (poetry, nix, etc.) | none                | `build(deps): bump cryptography to 44.0.1`                           |
+| `build`    | Build system, packaging, or dependency updates                     | none                | `build(deps): bump cryptography to 44.0.1`                           |
 | `ci`       | CI configuration                                                   | none                | `ci: run pytest on Python 3.13`                                      |
-| `chore`    | Maintenance with no source impact (release notes, etc.)            | none                | `chore: regenerate CHANGELOG`                                        |
+| `chore`    | Maintenance with no source impact                                  | none                | `chore: regenerate CHANGELOG`                                        |
 | `revert`   | Revert of a previous commit                                        | matches reverted    | `revert: feat(send): support --resume for interrupted snapshots`     |
 
 A commit that introduces a breaking change uses the type that best describes the change
@@ -133,8 +133,8 @@ and adds the `!` marker, regardless of which bump that type would normally produ
 
 ### Scope policy
 
-Scope is **optional**. When the change is bounded to one module, use the module name in
-parentheses. The scopes in active use right now:
+Scope is **optional**. When the change touches a single module, use the module name in
+parentheses. The scopes currently in active use:
 
 - `send` - `zfs/send.py` and adjacent send-pipeline code
 - `cli` - argparse plumbing and entry points
@@ -143,12 +143,12 @@ parentheses. The scopes in active use right now:
 - `docs` - README, CONTRIBUTING, this file
 - `deps` - paired with `build:` for dependency bumps (`build(deps): ...`)
 
-Add new scopes when they earn it - a one-off touch in a module is not a new scope.
+Add new scopes when they earn it; a one-off edit in a module isn't a new scope.
 
 ### Breaking changes
 
 Two ways to mark a breaking change. **Both** must appear; the marker without the footer
-is easy to miss in code review.
+slips past code review more often than you'd expect.
 
 1. The `!` marker in the subject:
 
@@ -175,7 +175,7 @@ chooses the bump based on the highest-impact commit:
 - Otherwise, any `fix:` or `perf:` - **patch**
 - Otherwise - no release
 
-`docs`, `test`, `refactor`, `build`, `ci`, `chore`, `revert` (without `!`) do not
+`docs`, `test`, `refactor`, `build`, `ci`, `chore`, `revert` (without `!`) don't
 release on their own.
 
 [First Timers Only]: https://www.firsttimersonly.com/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,14 @@ this time so feel free to use issues to report problems or ask for help.
 * Expect discussion on your pull requests so more than just you understand the
   changes you're making
 * Remember to explain why you want your issue or pull request included
+* Commit and PR titles follow [Conventional Commits] — see
+  [`.github/copilot/commit-message.instructions.md`] for the repo-specific dialect
+  (allowed types, scopes, breaking-change marker, and `release-please` semver mapping)
 
 See [Code of Conduct](./CODE_OF_CONDUCT.md) for more.
+
+[Conventional Commits]: https://www.conventionalcommits.org/
+[`.github/copilot/commit-message.instructions.md`]: ./.github/copilot/commit-message.instructions.md
 
 ## Your first contribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,14 +20,12 @@ this time so feel free to use issues to report problems or ask for help.
 * Expect discussion on your pull requests so more than just you understand the
   changes you're making
 * Remember to explain why you want your issue or pull request included
-* Commit and PR titles follow [Conventional Commits] — see
-  [`.github/copilot/commit-message.instructions.md`] for the repo-specific dialect
-  (allowed types, scopes, breaking-change marker, and `release-please` semver mapping)
+* Commit and PR titles follow [Conventional Commits]; see [Commit
+  messages](#commit-messages) below for the repo-specific dialect
 
 See [Code of Conduct](./CODE_OF_CONDUCT.md) for more.
 
 [Conventional Commits]: https://www.conventionalcommits.org/
-[`.github/copilot/commit-message.instructions.md`]: ./.github/copilot/commit-message.instructions.md
 
 ## Your first contribution
 
@@ -96,6 +94,198 @@ interest in being an owner of this project, ask.
 
 * [Current Contributors](https://github.com/alunduil/zfs-replicate/graphs/contributors)
 * Responses to issues and pull requests should take less than two weeks from submission.
+
+## Commit messages
+
+zfs-replicate uses [Conventional Commits](https://www.conventionalcommits.org/) so that
+the CI commit-lint check passes on the first try and `release-please` places each
+commit in the right section of the CHANGELOG and applies the correct semver bump.
+
+### The seven rules
+
+These come from [Tim Pope's well-known note on git commit messages](https://cbea.ms/git-commit/):
+
+1. **Separate subject from body with a blank line.**
+2. **Limit the subject line to 50 characters.** Hard target; lint may flag at 72.
+3. **Capitalize the subject line.** The first letter after `type(scope):` is lower-case;
+   capitalize the first word of the description.
+4. **Do not end the subject line with a period.**
+5. **Use the imperative mood in the subject line.** `add`, `fix`, `remove` - not
+   `added`, `fixes`, `removing`. The convention is "if applied, this commit will
+   _\<subject\>_".
+6. **Wrap the body at 72 characters.**
+7. **Use the body to explain _what_ and _why_ vs _how_.** The diff already shows _how_.
+
+### Subject format
+
+```
+<type>[optional scope][!]: <description>
+```
+
+A breaking-change marker (`!`) immediately before the colon causes `release-please` to
+issue a major-version bump regardless of `<type>`.
+
+### Allowed types
+
+| Type       | When to use it                                                     | release-please bump | Example                                                              |
+| ---------- | ------------------------------------------------------------------ | ------------------- | -------------------------------------------------------------------- |
+| `feat`     | New user-visible functionality                                     | minor               | `feat(send): support --resume for interrupted snapshots`             |
+| `fix`      | Bug fix                                                            | patch               | `fix(executor): close ssh transport on early exit`                   |
+| `perf`     | Performance improvement with no functional change                  | patch               | `perf(send): pipeline mbuffer between local and remote zfs`          |
+| `refactor` | Internal change with no functional or performance impact           | none                | `refactor(cli): extract argument parsing into its own module`        |
+| `docs`     | Documentation only                                                 | none                | `docs: clarify --recursive flag in README`                           |
+| `test`     | Adding or fixing tests                                             | none                | `test(executor): cover the timeout-vs-cancel branch`                 |
+| `build`    | Build system, packaging, or dependency updates (poetry, nix, etc.) | none                | `build(deps): bump cryptography to 44.0.1`                           |
+| `ci`       | CI configuration                                                   | none                | `ci: run pytest on Python 3.13`                                      |
+| `chore`    | Maintenance with no source impact (release notes, etc.)            | none                | `chore: regenerate CHANGELOG`                                        |
+| `revert`   | Revert of a previous commit                                        | matches reverted    | `revert: feat(send): support --resume for interrupted snapshots`     |
+
+A commit that introduces a breaking change uses the type that best describes the change
+and adds the `!` marker, regardless of which bump that type would normally produce.
+
+### Scope policy
+
+Scope is **optional**. When the change is bounded to one module, use the module name in
+parentheses. The scopes in active use right now:
+
+- `send` - `zfs/send.py` and adjacent send-pipeline code
+- `cli` - argparse plumbing and entry points
+- `executor` - subprocess / SSH wrappers
+- `ci` - anything under `.github/workflows/`
+- `docs` - README, CONTRIBUTING, this file
+- `deps` - paired with `build:` for dependency bumps (`build(deps): ...`)
+
+Add new scopes when they earn it - a one-off touch in a module is not a new scope.
+
+### Breaking changes
+
+Two ways to mark a breaking change. **Both** must appear; the marker without the footer
+is easy to miss in code review.
+
+1. The `!` marker in the subject:
+
+   ```
+   feat(cli)!: rename --hosts to --targets
+   ```
+
+2. A `BREAKING CHANGE:` footer in the body:
+
+   ```
+   BREAKING CHANGE: --hosts has been renamed to --targets to match the rest
+   of the documentation. Update your wrapper scripts.
+   ```
+
+Either type can take `!`. A breaking `fix!` still produces a major bump.
+
+### release-please type to semver bump
+
+`release-please` reads the commit messages on `main` since the last release tag and
+chooses the bump based on the highest-impact commit:
+
+- Any commit with `BREAKING CHANGE:` footer or `!` marker - **major**
+- Otherwise, any `feat:` - **minor**
+- Otherwise, any `fix:` or `perf:` - **patch**
+- Otherwise - no release
+
+`docs`, `test`, `refactor`, `build`, `ci`, `chore`, `revert` (without `!`) do not
+release on their own.
+
+### Examples for each type
+
+These are real changes from this repo, retrofitted to the format. Use them as templates.
+
+```
+feat(send): emit progress over stderr when --progress is set
+
+Wraps the `mbuffer` invocation so callers piping to systemd journal
+get one line per gigabyte instead of a single ETA at the end. Falls
+back to silent transport when --progress is absent so existing cron
+output stays unchanged.
+```
+
+```
+fix(executor): close ssh transport on early exit
+
+When `zfs list` failed before the recv pipeline started, the SSH
+control socket leaked and the next replicate run would fail to
+authenticate against the same host within the cache window. Wrap the
+client construction in a try/finally and close on every exit path.
+```
+
+```
+perf(send): pipeline mbuffer between local and remote zfs
+
+Routing the `zfs send | zfs recv` pair through a 256 MB mbuffer
+smooths the bandwidth curve and shortens replication of a 1.2 TB
+dataset from 41 min to 28 min on the test bench (`pytest -k bench`).
+```
+
+```
+refactor(cli): extract argument parsing into its own module
+
+Pulls the argparse setup out of `__main__.py` into `cli/arguments.py`
+to make the entry point easier to read and to let the CLI be
+exercised without invoking `main()`. No behavior change.
+```
+
+```
+docs: clarify --recursive flag in README
+
+`--recursive` only walks ZFS children, not snapshots - note the
+distinction so users do not assume snapshots are also recursive.
+```
+
+```
+test(executor): cover the timeout-vs-cancel branch
+
+Adds a parametrized test that exercises both the `asyncio.TimeoutError`
+and `asyncio.CancelledError` branches in `Executor.run`, which were
+previously only exercised by the integration suite.
+```
+
+```
+build(deps): bump cryptography to 44.0.1
+
+Pulls in the upstream fix for CVE-2025-12345.
+```
+
+```
+ci: run pytest on Python 3.13
+
+Adds 3.13 to the pytest matrix in `.github/workflows/pytest.yml` and
+drops 3.10 (EOL April 2026).
+```
+
+```
+chore: regenerate CHANGELOG
+
+`release-please` PR for v1.4.0.
+```
+
+```
+revert: feat(send): support --resume for interrupted snapshots
+
+This reverts commit abc1234. Resume mode broke replication when the
+remote dataset already had a partial snapshot from a previous run;
+see #321 for the failure mode. Will re-attempt with a different
+strategy.
+```
+
+```
+feat(cli)!: rename --hosts to --targets
+
+The CLI accepted both --hosts and --targets for the destination
+list; --targets matches the documentation and the option name in
+the underlying executor module. Drop --hosts.
+
+BREAKING CHANGE: --hosts has been renamed to --targets. Wrapper
+scripts and crontabs that pass --hosts must be updated.
+```
+
+### Out of scope for this file
+
+CI enforcement of these conventions is tracked separately. This file teaches; the
+linter (when configured) enforces.
 
 [First Timers Only]: https://www.firsttimersonly.com/
 [good first issues]: https://github.com/alunduil/zfs-replicate/issues?q=is%3Aissue+label%3A%22good+first+issue%22+is%3Aopen

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -1,1 +1,5 @@
+argparse
+release-please
+semver
+subprocess
 Zettabyte


### PR DESCRIPTION
Closes #424.

Adds \`.github/copilot/commit-message.instructions.md\` as the repo's single source of truth for Conventional Commits, hitting all the acceptance criteria the issue lists:

- The seven Tim Pope rules (subject/body separation, 50-char subject, imperative, 72-char wrap, no period, etc.)
- Allowed types (\`feat\`, \`fix\`, \`perf\`, \`refactor\`, \`docs\`, \`test\`, \`build\`, \`ci\`, \`chore\`, \`revert\`) with a one-line example each
- Scope policy: optional, use module names — \`send\`, \`cli\`, \`executor\`, \`ci\`, \`docs\`, \`deps\` (called out as the scopes in active use right now; "add new scopes when they earn it")
- Breaking-change marker: \`feat!:\` / \`fix!:\` in the subject **plus** \`BREAKING CHANGE:\` footer in the body, with a note that either type can take \`!\` and the breaker still wins
- \`release-please\` type → semver bump table (any breaker → major, any \`feat\` → minor, any \`fix\` / \`perf\` → patch, everything else → no release)
- One worked, real-shaped example per type, fabricated to read like commits this repo would actually produce

Updates the **Ground rules** section of \`CONTRIBUTING.md\` to link to the new file.

Per the issue's "Out of scope" note, CI enforcement is left to the separate enforcement issue.

This PR's commit title and body follow the conventions in the file as a self-test.