### PR TITLE
fix(test): use f-string in SNAPSHOTS filesystem strategy

### DIFF
--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -18,7 +18,7 @@ _NOT_WHITESPACE = [
     x for x in string.printable if x not in string.whitespace and x != "@"
 ]
 
-_FILESYSTEMS = text(_NOT_WHITESPACE).map(lambda x: "a{x}").map(filesystem)
+_FILESYSTEMS = text(_NOT_WHITESPACE, min_size=1).map(lambda x: f"a{x}").map(filesystem)
 
 _SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
     "filesystem": _FILESYSTEMS,

--- a/zfs_test/replicate_test/snapshot_test/type_test.py
+++ b/zfs_test/replicate_test/snapshot_test/type_test.py
@@ -3,19 +3,9 @@
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.type import Snapshot
 
-from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
-
 
 def test_eq_ignore_previous() -> None:
     """Ignore previous in Snapshot equality."""
     zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
     previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
     assert zero == previous  # nosec
-
-
-def test_filesystem_names_are_varied() -> None:
-    """Sanity check: the filesystem strategy produces at least two distinct names."""
-    seen = set()
-    for _ in range(50):
-        seen.add(str(SNAPSHOTS.example().filesystem))
-    assert len(seen) >= 2, "Expected varied filesystem names, got: " + repr(seen)

--- a/zfs_test/replicate_test/snapshot_test/type_test.py
+++ b/zfs_test/replicate_test/snapshot_test/type_test.py
@@ -3,9 +3,19 @@
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.type import Snapshot
 
+from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
+
 
 def test_eq_ignore_previous() -> None:
     """Ignore previous in Snapshot equality."""
     zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
     previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
     assert zero == previous  # nosec
+
+
+def test_filesystem_names_are_varied() -> None:
+    """Sanity check: the filesystem strategy produces at least two distinct names."""
+    seen = set()
+    for _ in range(50):
+        seen.add(str(SNAPSHOTS.example().filesystem))
+    assert len(seen) >= 2, "Expected varied filesystem names, got: " + repr(seen)


### PR DESCRIPTION
The `SNAPSHOTS` strategy in `strategies.py:21` used a plain string literal `"a{x}"` instead of an f-string, producing the same filesystem name for every Hypothesis example. All property tests depending on `SNAPSHOTS` (generator, planner, list parser) exercised only single-filesystem scenarios.

Changes:
- `strategies.py`: `"a{x}"` → `f"a{x}"`, added `min_size=1` to prevent empty strings
- `type_test.py`: added test asserting at least two distinct filesystem names appear across 50 Hypothesis examples

Closes #405
