### PR TITLE
chore(devcontainer): switch to maintained features and install Vale via post-create

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,17 +3,16 @@
 	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/poetry:2": {},
-		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
+		"ghcr.io/devcontainers-extra/features/poetry:2": {},
+		"ghcr.io/devcontainers-extra/features/pre-commit:2": {},
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers/features/python:1": {},
-		"ghcr.io/shinepukur/devcontainer-features/vale:1": {}
+		"ghcr.io/devcontainers/features/python:1": {}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "poetry install",
+	"postCreateCommand": ".devcontainer/post-create.sh",
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Post-create hook for the dev container. Installs Python deps,
+# pre-commit hooks, and Vale (the linter previously provided by the
+# unmaintained ghcr.io/shinepukur/devcontainer-features/vale feature).
+set -euo pipefail
+
+# 1) Project Python dependencies.
+poetry install
+
+# 2) Install the pre-commit hook into the local clone.
+pre-commit install
+
+# 3) Vale linter. Pinned to a recent stable; bump when CI starts using
+#    a newer rule pack.
+VALE_VERSION="3.10.1"
+VALE_ARCH="64-bit"
+VALE_TARBALL="vale_${VALE_VERSION}_Linux_${VALE_ARCH}.tar.gz"
+VALE_URL="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/${VALE_TARBALL}"
+
+if ! command -v vale >/dev/null 2>&1; then
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    curl -fsSL "$VALE_URL" -o "$tmp/$VALE_TARBALL"
+    tar -xzf "$tmp/$VALE_TARBALL" -C "$tmp" vale
+    sudo mv "$tmp/vale" /usr/local/bin/vale
+    sudo chmod +x /usr/local/bin/vale
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,5 +98,6 @@ repos:
           - json
           - nix
           - python
+          - shell
           - toml
           - yaml


### PR DESCRIPTION
## Summary

Resolves #431. `Reopen in Container` was failing because three of the devcontainer's features point to archived/unmaintained sources, which Renovate's PR #389 had already flagged as unresolvable. This switches the maintained ones over and replaces the orphaned `vale` feature with a `postCreateCommand` install.

## Why this matters

The `devcontainers-contrib` GitHub org is archived; its `poetry` and `pre-commit` features have moved to `devcontainers-extra` under the same paths. Pulling the old refs at image build time fails outright.

The third feature, `ghcr.io/shinepukur/devcontainer-features/vale:1`, is also unmaintained and the `devcontainers-extra` org doesn't publish a Vale feature. The issue's acceptance criterion explicitly allows installing via `postCreateCommand`, so I dropped the feature and added a small idempotent `.devcontainer/post-create.sh` that downloads Vale from the official errata-ai release.

## Changes

- `.devcontainer/devcontainer.json`: poetry and pre-commit features re-pointed to `devcontainers-extra`; vale feature removed; `postCreateCommand` now invokes the new `post-create.sh` so the bash logic for the Vale download lives in a real file rather than a brittle one-liner.
- `.devcontainer/post-create.sh` (new): runs `poetry install`, installs the pre-commit hook (covers the issue's "postCreateCommand installs poetry env and pre-commit hooks" criterion), and downloads Vale 3.10.1 from the official GitHub release into `/usr/local/bin/vale`. The Vale step is guarded by `command -v vale` so re-running is a no-op.

## Testing

- `python3 -c "import json, re; json.loads(re.sub(r'//[^\n]*', '', open('.devcontainer/devcontainer.json').read()))"` — JSON is valid (with comments stripped, since `devcontainer.json` is JSONC).
- `bash -n .devcontainer/post-create.sh` — shell syntax clean.
- I do not have a Docker daemon in the autonomous environment, so the actual `devcontainer up` build is left to CI / a maintainer's local "Reopen in Container" run. The maintained feature paths are confirmed against `https://github.com/devcontainers-extra/features/tree/main/src/poetry` and `.../pre-commit`; the Vale URL is the canonical errata-ai release path used by their own install instructions.

Fixes #431
