### PR TITLE
fix: align Snapshot equality on slash boundaries

### DIFF
--- a/zfs/replicate/snapshot/type.py
+++ b/zfs/replicate/snapshot/type.py
@@ -23,10 +23,10 @@ class Snapshot:
         if not isinstance(other, Snapshot):
             raise NotImplementedError
 
-        is_suffix = self.filesystem.name.endswith(
-            other.filesystem.name
-        ) or other.filesystem.name.endswith(
-            self.filesystem.name,
+        left = self.filesystem.name
+        right = other.filesystem.name
+        is_suffix = (
+            left == right or left.endswith("/" + right) or right.endswith("/" + left)
         )
 
         return (

--- a/zfs_test/replicate_test/snapshot_test/type_test.py
+++ b/zfs_test/replicate_test/snapshot_test/type_test.py
@@ -9,3 +9,28 @@ def test_eq_ignore_previous() -> None:
     zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
     previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
     assert zero == previous  # nosec
+
+
+def test_eq_rejects_unaligned_suffix() -> None:
+    """Snapshots on unrelated datasets sharing a name suffix are not equal."""
+    local = Snapshot(
+        filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0
+    )
+    remote = Snapshot(
+        filesystem=filesystem("bigpool/data"), name="snap", previous=None, timestamp=0
+    )
+    assert local != remote  # nosec
+
+
+def test_eq_accepts_slash_aligned_suffix() -> None:
+    """A remote rebased under another dataset stays equal to its local origin."""
+    local = Snapshot(
+        filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0
+    )
+    remote = Snapshot(
+        filesystem=filesystem("backup/pool/data"),
+        name="snap",
+        previous=None,
+        timestamp=0,
+    )
+    assert local == remote  # nosec


### PR DESCRIPTION
## Summary

Snapshot equality now refuses to bridge across unrelated datasets that happen to share a name suffix, so the task planner can no longer pick a CREATE/DESTROY/SEND action against the wrong dataset (`pool/data` vs `bigpool/data`).

## Verification

- Ran `poetry run pytest zfs_test/` in the devcontainer — 21 passed (including Hypothesis property tests).

Closes #390