### PR TITLE
chore: prepare 4.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## unreleased
 
+## 4.0.1 -- 2026-05-08
+
+### Fixed
+
+- Snapshot equality no longer matches across unrelated data sets that share a name suffix (for example, `pool/data` and `bigpool/data`), preventing the task planner from acting on the wrong data set (#390).
+
 ## 4.0.0 -- 2024-11-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ name = "zfs-replicate"
 packages = [{include = "zfs"}, {include = "zfs_test", format = "sdist"}]
 readme = "README.md"
 repository = "https://github.com/alunduil/zfs-replicate"
-version = "4.0.0"
+version = "4.0.1"
 
 [tool.poetry.dependencies]
 click = "^8.1.3"


### PR DESCRIPTION
## Summary

Bumps `zfs-replicate` to 4.0.1 and promotes the `unreleased` CHANGELOG section. The only user-visible change since 4.0.0 is the snapshot-equality fix from #390 (landed via #439).

## Gotchas

- After merge, the release still has to be cut by hand (tag + GitHub Release) since release-please isn't wired up yet (#415). Publishing then runs automatically via `.github/workflows/publish.yml` on the `release: published` event.
- `PYPI_API_TOKEN` is from 2022-12-11; worth a sanity check before tagging. Stale `PYPI_USERNAME` / `PYPI_PASSWORD` secrets from 2021 are unused by the workflow and can be deleted post-release.

Closes #390 milestone work (issue itself was closed by #439).