### PR TITLE
feat(cli): add --raw / --no-raw to zfs send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Added
+
+- `--raw / --no-raw` toggles `zfs send --raw`. The default `--raw` preserves the existing behaviour for encrypted datasets; pass `--no-raw` when replicating to a destination that can't preserve encryption (#391).
+
 ## 4.0.1 -- 2026-05-08
 
 ### Fixed

--- a/zfs/replicate/cli/main.py
+++ b/zfs/replicate/cli/main.py
@@ -61,6 +61,15 @@ from .click import EnumChoice
     default=Compression.LZ4,
     help="One of: off (no compression), lz4 (fastest), pigz (all rounder), or plzip (best compression).",
 )
+@click.option(  # type: ignore[misc]
+    "--raw/--no-raw",
+    default=True,
+    help=(
+        "Pass --raw to zfs send so encrypted datasets replicate without"
+        " decryption (default). Use --no-raw to send decrypted data, for"
+        " example when the destination cannot preserve encryption."
+    ),
+)
 @click.argument("host", required=True)  # type: ignore[misc]
 @click.argument("remote_fs", type=filesystem_t, required=True, metavar="REMOTE_FS")  # type: ignore[misc]
 @click.argument("local_fs", type=filesystem_t, required=True, metavar="LOCAL_FS")  # type: ignore[misc]
@@ -74,6 +83,7 @@ def main(  # pylint: disable=R0917,R0914,R0913
     identity_file: str,
     cipher: Cipher,
     compression: Compression,
+    raw: bool,
     host: str,
     remote_fs: FileSystem,
     local_fs: FileSystem,
@@ -134,5 +144,6 @@ def main(  # pylint: disable=R0917,R0914,R0913
             filesystem_tasks,
             follow_delete=follow_delete,
             compression=compression,
+            raw=raw,
             ssh_command=ssh_command,
         )

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -16,10 +16,11 @@ def send(  # pylint: disable=R0917,R0913
     ssh_command: str,
     compression: Compression,
     follow_delete: bool,
+    raw: bool,
     previous: Optional[Snapshot] = None,
 ) -> None:
     """Send ZFS Snapshot."""
-    send_command = _send(current, previous, follow_delete=follow_delete)
+    send_command = _send(current, previous, follow_delete=follow_delete, raw=raw)
 
     compress_command, decompress_command = compress.command(compression)
 
@@ -52,9 +53,15 @@ def send(  # pylint: disable=R0917,R0913
 
 
 def _send(
-    current: Snapshot, previous: Optional[Snapshot] = None, follow_delete: bool = False
+    current: Snapshot,
+    previous: Optional[Snapshot] = None,
+    follow_delete: bool = False,
+    raw: bool = True,
 ) -> str:
-    options = ["--raw"]  # ["-V"]
+    options = []
+
+    if raw:
+        options.append("--raw")
 
     if follow_delete:
         options.append("-p")

--- a/zfs/replicate/task/execute.py
+++ b/zfs/replicate/task/execute.py
@@ -9,12 +9,13 @@ from ..filesystem import FileSystem
 from .type import Action, Task
 
 
-def execute(
+def execute(  # pylint: disable=R0917,R0913
     remote: FileSystem,
     tasks: List[Tuple[FileSystem, List[Task]]],
     ssh_command: str,
     follow_delete: bool,
     compression: Compression,
+    raw: bool,
 ) -> None:
     """Execute all tasks."""
     sorted_tasks = sorted(tasks, key=lambda x: len(x[0].name.split("/")), reverse=True)
@@ -39,6 +40,7 @@ def execute(
                     ssh_command=ssh_command,
                     follow_delete=follow_delete,
                     compression=compression,
+                    raw=raw,
                 )
 
 
@@ -55,12 +57,13 @@ def _destroy(tasks: List[Task], ssh_command: str) -> None:
             snapshot.destroy(task.snapshot, ssh_command=ssh_command)
 
 
-def _send(
+def _send(  # pylint: disable=R0917,R0913
     remote: FileSystem,
     tasks: List[Task],
     ssh_command: str,
     follow_delete: bool,
     compression: Compression,
+    raw: bool,
 ) -> None:
     for task in tasks:
         snapshot.send(
@@ -69,5 +72,6 @@ def _send(
             ssh_command=ssh_command,
             compression=compression,
             follow_delete=follow_delete,
+            raw=raw,
             previous=optional.value(task.snapshot).previous,
         )

--- a/zfs_test/replicate_test/cli_test/main_test.py
+++ b/zfs_test/replicate_test/cli_test/main_test.py
@@ -1,8 +1,14 @@
 """zfs.replicate.cli.main tests."""
 
+from typing import Any, Dict, List
+
+import pytest
 from click.testing import CliRunner
 
 from zfs.replicate.cli.main import main
+from zfs.replicate.filesystem.type import filesystem
+from zfs.replicate.snapshot.send import _send
+from zfs.replicate.snapshot.type import Snapshot
 
 
 def test_invokes_without_stacktrace() -> None:
@@ -20,6 +26,51 @@ def test_invokes_without_stacktrace() -> None:
         isinstance(result.exception, FileNotFoundError)
         and result.exception.filename == "/usr/bin/env"
     ), "Expected SystemExit or FileNotFoundError."
+
+
+def test_no_raw_threads_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--no-raw` reaches task.execute and the resulting send command omits --raw.
+
+    .. code:: bash
+
+        zfs-replicate --no-raw -l alunduil -i mypy.ini example.com bogus bogus
+    """
+    captured: Dict[str, Any] = {}
+
+    def fake_list(*_args: Any, **_kwargs: Any) -> List[Snapshot]:
+        return []
+
+    def fake_create(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def fake_execute(*_args: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("zfs.replicate.cli.main.snapshot.list", fake_list)
+    monkeypatch.setattr("zfs.replicate.cli.main.filesystem.create", fake_create)
+    monkeypatch.setattr("zfs.replicate.cli.main.task.execute", fake_execute)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--no-raw",
+            "-l",
+            "alunduil",
+            "-i",
+            "mypy.ini",
+            "example.com",
+            "bogus",
+            "bogus",
+        ],
+    )
+    assert result.exit_code == 0, result.output  # nosec
+    assert captured.get("raw") is False  # nosec
+
+    snapshot = Snapshot(
+        filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0
+    )
+    assert "--raw" not in _send(snapshot, raw=captured["raw"])  # nosec
 
 
 def test_invokes_without_stacktrace_verbose() -> None:

--- a/zfs_test/replicate_test/snapshot_test/send_test.py
+++ b/zfs_test/replicate_test/snapshot_test/send_test.py
@@ -1,0 +1,27 @@
+"""zfs.replicate.snapshot.send tests."""
+
+from zfs.replicate.filesystem.type import filesystem
+from zfs.replicate.snapshot.send import _send
+from zfs.replicate.snapshot.type import Snapshot
+
+
+def test_send_includes_raw_by_default() -> None:
+    """_send embeds --raw when raw is True."""
+    snapshot = Snapshot(
+        filesystem=filesystem("pool/data"),
+        name="snap",
+        previous=None,
+        timestamp=0,
+    )
+    assert "--raw" in _send(snapshot, raw=True)  # nosec
+
+
+def test_send_omits_raw_when_disabled() -> None:
+    """_send omits --raw when raw is False."""
+    snapshot = Snapshot(
+        filesystem=filesystem("pool/data"),
+        name="snap",
+        previous=None,
+        timestamp=0,
+    )
+    assert "--raw" not in _send(snapshot, raw=False)  # nosec


### PR DESCRIPTION
## Summary

`zfs-replicate` now exposes `--raw / --no-raw`, restoring operator agency over whether `zfs send --raw` is appended. Default `--raw` preserves today's behaviour for encrypted datasets; `--no-raw` lets users replicate to destinations that can't preserve encryption.

Closes #391.

## Gotchas

- The flag threads through three call sites (`cli/main.py` → `task/execute.py` → `snapshot/send.py`); the new `raw` parameter is required at each boundary so a missing wire-up surfaces as a type error.
- `_send` now builds `options` starting empty rather than seeded with `["--raw"]`. Worth a glance to confirm the `-p` / `-i ...` ordering still produces a valid `zfs send` invocation.

## Verification

- `pytest` (24 passed) including new `_send` raw-on/off cases and a CLI integration that asserts `--no-raw` reaches `task.execute` and yields a send command without `--raw`.
- `--help` rendered locally to confirm the new option appears with encrypted-dataset wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)