### PR TITLE
chore: prepare 4.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+## 4.1.0 -- 2026-05-08
+
 ### Added
 
 - `--raw / --no-raw` toggles `zfs send --raw`. The default `--raw` preserves the existing behaviour for encrypted datasets; pass `--no-raw` when replicating to a destination that can't preserve encryption (#391).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ name = "zfs-replicate"
 packages = [{include = "zfs"}, {include = "zfs_test", format = "sdist"}]
 readme = "README.md"
 repository = "https://github.com/alunduil/zfs-replicate"
-version = "4.0.1"
+version = "4.1.0"
 
 [tool.poetry.dependencies]
 click = "^8.1.3"


### PR DESCRIPTION
## Summary

Bumps `zfs-replicate` to 4.1.0 and promotes the `unreleased` CHANGELOG section. The user-visible change since 4.0.1 is the new `--raw / --no-raw` flag from #391 (landed via #442).

## Gotchas

- Same manual cut as 4.0.1 — after merge, tag `v4.1.0` and create the GitHub Release by hand (release-please still tracked under #415). `.github/workflows/publish.yml` then runs on `release: published` and uploads to PyPI.
- `PYPI_API_TOKEN` was last touched 2022-12-11; sanity-check it before tagging if the 4.0.1 cut didn't already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)