### PR TITLE
docs: create CLAUDE.md with tooling inventory and scope discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Claude.md
+
+Repository-specific guidance for Claude Code working in `zfs-replicate`. Keep this short, with repo-specific guidance.
+
+## Tools inventory
+
+Before reaching for `curl`, hand-rolled API calls, or first-principles scripts, see whether one of these already covers the task:
+
+- **Package manager**: Poetry. Manifest in `pyproject.toml`, lock in `poetry.lock`, project-local configuration in `poetry.toml`. Use `poetry run <cmd>` to enter the project's virtual environment.
+- **Development shell**: Nix via `shell.nix` (which sources `nix/shell.nix`). `direnv` reads `.envrc`, and `.devcontainer/` keeps the GitHub Codespaces and Visual Studio Code Remote Containers configuration in sync.
+- **Tests**: `pytest` configured under `[tool.pytest.ini_options]` in `pyproject.toml` (`--doctest-modules --cov=zfs --cov-report=term-missing`, `testpaths = ["zfs_test"]`). Doctest coverage is part of the suite, so don't break docstrings. Hypothesis is available.
+- **Lint, format, type, and prose**: All wired through `pre-commit` (`.pre-commit-config.yaml`). The bundle covers `black`, `isort`, `flake8` (`.flake8`), `bandit`, `pylint` (`.pylintrc`), `pydocstyle`, `mypy` (`mypy.ini`), and Vale prose linting (`.vale.ini`, with custom rules under `styles/`). Run `poetry run pre-commit run --all-files` before requesting review.
+- **Entry point**: `zfs-replicate = "zfs.replicate.cli.main:main"` (registered in `pyproject.toml`'s `[tool.poetry.scripts]`).
+- **Source layout**: implementation under `zfs/replicate/`, tests under `zfs_test/replicate_test/`.
+
+## Scope discipline
+
+This repository has five open release milestones (`4.2.0` through `5.0.0`) and uses a `blocked` label to sequence work. Pull requests that bleed into sibling issues or land code for a milestone whose prerequisites haven't shipped have caused friction in past sessions. Before opening a pull request:
+
+- Verify the change doesn't overlap with linked or sibling issues. If uncertain, ask in the issue rather than guess.
+- If the issue is blocked by unshipped prerequisites (look for the `blocked` label or `blocked-by` references), propose deferral via a comment rather than writing premature code.
+- Revert out-of-scope incidental edits (formatting drive-bys, unrelated refactors) before requesting review, so the diff stays matched to the issue's acceptance criteria.
+
+Most of the above is also encoded in the user-level `issue-work` skill; this file exists so the discipline applies even when that skill isn't loaded.

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -1,5 +1,9 @@
 argparse
+Codespaces
+docstrings
+Doctest
 release-please
 semver
 subprocess
+unshipped
 Zettabyte


### PR DESCRIPTION
## Summary

Creates the `CLAUDE.md` that the `/insights` review on 2026-05-17 asked for, plus the four small vocabulary additions needed for the file to pass Vale prose linting in `pre-commit`.

Closes #445

## Why

The two friction patterns called out in the issue (`curl`/manual-API/first-principles work when Poetry, pre-commit, or Nix already covered the task; and scope bleed into sibling milestones in a repo that explicitly uses `blocked` to sequence work) both keep showing up because the repo had no `CLAUDE.md` to surface what was already available. Adding the file means the first move in a fresh session is discovery against a calibrated inventory, not reinvention - and the scope rules apply even when the `issue-work` skill isn't loaded.

## What changed

- `CLAUDE.md` (new): two short sections, both calibrated to this repo:
  - **Tools inventory**: Poetry, Nix dev shell, `direnv` / `.devcontainer/`, `pytest` invocation flags, the eight-tool `pre-commit` bundle including Vale, the `zfs-replicate` entry point, and the `zfs/replicate/` source layout. Verified each claim by reading the on-disk file (`pyproject.toml`, `shell.nix`, `nix/shell.nix`, `.envrc`, `.devcontainer/`, `.pre-commit-config.yaml`, `.flake8`, `.pylintrc`, `mypy.ini`, `.vale.ini`, `styles/`, `pyproject.toml:[tool.poetry.scripts]`).
  - **Scope discipline**: notes the five open release milestones (`4.2.0`-`5.0.0`) and the `blocked` label convention, with three concrete rules (sibling-overlap check, defer-on-prerequisites, revert out-of-scope edits before review).
- `styles/config/vocabularies/ZFS/accept.txt`: adds `Codespaces`, `Doctest`, `docstrings`, `unshipped` to the project's Vale vocab so the new file passes `pre-commit` (`vale --minAlertLevel=error` is clean after this change). The four words are project-domain terms that belong in vocab rather than the prose.

Token-efficient prose per the acceptance criteria - only repo-specific guidance, no generic best-practice filler.

## Verification

- `vale --minAlertLevel=error CLAUDE.md` is clean.
- Verified each tooling claim against the on-disk file paths listed above.
