### PR TITLE
docs(claude): add CLAUDE.md with tooling inventory and scope discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,34 +6,18 @@ Repository-specific guidance for Claude Code sessions. The two sections below co
 
 Discover existing tooling before reaching for `curl`, manual API calls, or first-principles scripts. The following is what this repository already ships:
 
-- **Package manager:** [`Poetry`] (`pyproject.toml` plus `poetry.lock`, `poetry.toml`).
-- **Development shell:** [`Nix`] (`shell.nix` imports `nix/shell.nix`); `.envrc` for [`direnv`]; `.devcontainer/` for Visual Studio Code.
+- **Package manager:** `Poetry` (`pyproject.toml` plus `poetry.lock`, `poetry.toml`).
+- **Development shell:** `Nix` (`shell.nix` imports `nix/shell.nix`); `.envrc` for `direnv`; `.devcontainer/` for Visual Studio Code.
 - **Entry point:** `zfs-replicate = "zfs.replicate.cli.main:main"` (defined under `[tool.poetry.scripts]`).
-- **Tests:** [`pytest`] with `--doctest-modules --cov=zfs --cov-report=term-missing` (configured in `pyproject.toml`); test tree under `zfs_test/`; [`Hypothesis`] is available as a development dependency.
-- **Lint, format, and type-check:** [`pre-commit`] (`.pre-commit-config.yaml`) bundles [`black`], [`isort`], [`flake8`] (`.flake8`), [`bandit`], [`pylint`] (`.pylintrc`), [`pydocstyle`], [`mypy`] (`mypy.ini`, `strict = True`), and [`vulture`]. Prose linting uses [`Vale`] (`.vale.ini` plus `styles/`). Run `pre-commit run --all-files` before each commit rather than calling each tool individually.
+- **Tests:** `pytest` with `--doctest-modules --cov=zfs --cov-report=term-missing` (configured in `pyproject.toml`); test tree under `zfs_test/`; `Hypothesis` is available as a development dependency.
+- **Lint, format, and type-check:** `pre-commit` (`.pre-commit-config.yaml`) bundles `black`, `isort`, `flake8` (`.flake8`), `bandit`, `pylint` (`.pylintrc`), `pydocstyle`, `mypy` (`mypy.ini`, `strict = True`), and `vulture`. Prose linting uses `Vale` (`.vale.ini` plus `styles/`). Run `pre-commit run --all-files` before each commit rather than calling each tool individually.
 
 ## 2. Scope discipline
 
-Five release milestones (4.2.0 through 5.0.0) are open in parallel, and the `blocked` label is in active use. Issues are sequenced; out-of-scope edits and early work on blocked items have both caused churn here.
+Use GitHub milestones for current release scope. The `blocked` label is in active use. Issues are sequenced; out-of-scope edits and early work on blocked items have both caused churn here.
 
 - Before opening a pull request, verify the scope doesn't overlap with linked or sibling issues; if uncertain, ask in the issue first.
 - If an issue is blocked by unreleased prerequisites, propose deferral with `blocked-by` edges rather than writing early code.
 - Revert any out-of-scope incidental edits before requesting review. Lint and format changes that touch untouched files in the diff get reverted.
 
 The `issue-work` skill already encodes most of this; this file exists to remind Claude Code to apply it without having to call the skill.
-
-[`bandit`]: https://github.com/PyCQA/bandit
-[`black`]: https://github.com/psf/black
-[`direnv`]: https://direnv.net
-[`flake8`]: https://github.com/PyCQA/flake8
-[`Hypothesis`]: https://hypothesis.readthedocs.io
-[`isort`]: https://github.com/PyCQA/isort
-[`mypy`]: https://mypy.readthedocs.io
-[`Nix`]: https://nixos.org
-[`Poetry`]: https://python-poetry.org
-[`pre-commit`]: https://pre-commit.com
-[`pydocstyle`]: https://www.pydocstyle.org
-[`pylint`]: https://pylint.readthedocs.io
-[`pytest`]: https://docs.pytest.org
-[`Vale`]: https://vale.sh
-[`vulture`]: https://github.com/jendrikseipp/vulture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md for `zfs-replicate`
+
+Repository-specific guidance for Claude Code sessions. The two sections below cover friction patterns that have shown up repeatedly while working in this codebase. Keep edits here calibrated to this repository; generic best practices belong elsewhere.
+
+## 1. Tooling inventory
+
+Discover existing tooling before reaching for `curl`, manual API calls, or first-principles scripts. The following is what this repository already ships:
+
+- **Package manager:** [`Poetry`] (`pyproject.toml` plus `poetry.lock`, `poetry.toml`).
+- **Development shell:** [`Nix`] (`shell.nix` imports `nix/shell.nix`); `.envrc` for [`direnv`]; `.devcontainer/` for Visual Studio Code.
+- **Entry point:** `zfs-replicate = "zfs.replicate.cli.main:main"` (defined under `[tool.poetry.scripts]`).
+- **Tests:** [`pytest`] with `--doctest-modules --cov=zfs --cov-report=term-missing` (configured in `pyproject.toml`); test tree under `zfs_test/`; [`Hypothesis`] is available as a development dependency.
+- **Lint, format, and type-check:** [`pre-commit`] (`.pre-commit-config.yaml`) bundles [`black`], [`isort`], [`flake8`] (`.flake8`), [`bandit`], [`pylint`] (`.pylintrc`), [`pydocstyle`], [`mypy`] (`mypy.ini`, `strict = True`), and [`vulture`]. Prose linting uses [`Vale`] (`.vale.ini` plus `styles/`). Run `pre-commit run --all-files` before each commit rather than calling each tool individually.
+
+## 2. Scope discipline
+
+Five release milestones (4.2.0 through 5.0.0) are open in parallel, and the `blocked` label is in active use. Issues are sequenced; out-of-scope edits and early work on blocked items have both caused churn here.
+
+- Before opening a pull request, verify the scope doesn't overlap with linked or sibling issues; if uncertain, ask in the issue first.
+- If an issue is blocked by unreleased prerequisites, propose deferral with `blocked-by` edges rather than writing early code.
+- Revert any out-of-scope incidental edits before requesting review. Lint and format changes that touch untouched files in the diff get reverted.
+
+The `issue-work` skill already encodes most of this; this file exists to remind Claude Code to apply it without having to call the skill.
+
+[`bandit`]: https://github.com/PyCQA/bandit
+[`black`]: https://github.com/psf/black
+[`direnv`]: https://direnv.net
+[`flake8`]: https://github.com/PyCQA/flake8
+[`Hypothesis`]: https://hypothesis.readthedocs.io
+[`isort`]: https://github.com/PyCQA/isort
+[`mypy`]: https://mypy.readthedocs.io
+[`Nix`]: https://nixos.org
+[`Poetry`]: https://python-poetry.org
+[`pre-commit`]: https://pre-commit.com
+[`pydocstyle`]: https://www.pydocstyle.org
+[`pylint`]: https://pylint.readthedocs.io
+[`pytest`]: https://docs.pytest.org
+[`Vale`]: https://vale.sh
+[`vulture`]: https://github.com/jendrikseipp/vulture


### PR DESCRIPTION
## Summary

Adds the `CLAUDE.md` file requested in #445, covering the two friction patterns identified in the issue: tooling discovery and scope discipline. The file lives at the repository root next to `CONTRIBUTING.md` so Claude Code picks it up automatically when the working directory is opened.

## Why this matters

Per the issue, two patterns repeat in Claude Code sessions on this repo: reaching for `curl` or first-principles scripts when local tooling already covers the task, and bleeding scope across linked or blocked issues. The tooling inventory section lists exactly what this repo ships (Poetry, Nix shell, the full `pre-commit` stack, Vale, `pytest --doctest-modules --cov=zfs`, the `zfs-replicate` entry point) so the first move is discovery. The scope-discipline section names the five open milestones (4.2.0 through 5.0.0) and the `blocked` label as the reason ordering matters here.

I verified every claim against the current repo state:
- Poetry: confirmed `[tool.poetry]` in `pyproject.toml` plus `poetry.lock`, `poetry.toml`.
- Nix shell: `shell.nix` is one line, `import nix/shell.nix`.
- `.envrc` and `.devcontainer/` both present.
- Entry point: `zfs-replicate = "zfs.replicate.cli.main:main"` in `[tool.poetry.scripts]`.
- Pytest config in `pyproject.toml`: `addopts = "--doctest-modules --cov=zfs --cov-report=term-missing"`, `testpaths = ["zfs_test"]`.
- Hypothesis: `hypothesis = "^6.56.4"` listed under test dependencies.
- `pre-commit` hooks: black, isort, flake8, bandit, pylint, pydocstyle, mypy, vulture, Vale all enumerated in `.pre-commit-config.yaml`.
- `mypy.ini` declares `strict = True`.
- Five open milestones (4.2.0 through 5.0.0) and the `blocked` label both confirmed via `gh api`.

Wrote prose to clear Vale errors against the repo's configured style (`Google`, `Microsoft`, `write-good`, `proselint`, `alex`, `RedHat`). `vale CLAUDE.md` reports `0 errors`; remaining warnings are stylistic suggestions (e.g. `write-good.Passive`) that the existing `CONTRIBUTING.md` and `README.md` also carry.

## Acceptance criteria

- [x] `CLAUDE.md` created with a Tooling inventory and Scope discipline section, calibrated to this repo.
- [x] Token-efficient prose: only repo-specific guidance; no generic best-practice filler.

See #445.