### PR TITLE
ci(publish): pin setup-python's python-version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
+          python-version: "3.8"
           cache: poetry
       - name: poetry build
         run: poetry build


### PR DESCRIPTION
## Summary

`publish.yml` now passes an explicit `python-version: "3.8"` to `actions/setup-python`, which makes `cache: poetry` actually cache between runs and pins the build environment to a known interpreter.

## Verification

- CI's existing workflows will lint the YAML.
- Real validation happens at the next release: the publish run should no longer emit the "python-version input is not set" or "cache paths are empty" annotations seen on the v4.0.1 and v4.1.0 runs.

Closes #441