### PR TITLE
fix: preserve remote snapshot lookup key

### DIFF
--- a/zfs/replicate/task/generate.py
+++ b/zfs/replicate/task/generate.py
@@ -80,10 +80,10 @@ def generate(
                 ],
             )
 
-    for filesystem in remote_snapshots:
+    for remote_snapshot_filesystem in remote_snapshots:
         filesystem = filesystem_t(
-            name=filesystem.name.replace(remote.name + "/", ""),
-            readonly=filesystem.readonly,
+            name=remote_snapshot_filesystem.name.replace(remote.name + "/", ""),
+            readonly=remote_snapshot_filesystem.readonly,
         )
 
         if filesystem not in local_snapshots:
@@ -94,7 +94,7 @@ def generate(
                         filesystem=remote_filesystem(remote, filesystem),
                         snapshot=s,
                     )
-                    for s in remote_snapshots[filesystem]
+                    for s in remote_snapshots[remote_snapshot_filesystem]
                 ],
             )
             tasks.append(

--- a/zfs_test/replicate_test/task_test/generate_test.py
+++ b/zfs_test/replicate_test/task_test/generate_test.py
@@ -11,6 +11,7 @@ from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot import Snapshot
 from zfs.replicate.task.generate import generate
 from zfs.replicate.task.type import Action
+from zfs.replicate.task.type import Task
 from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
@@ -61,3 +62,30 @@ def test_empty_locals(snapshots: List[Snapshot]) -> None:
         map(len, snapshots_by_fs.values()),
     )
     assert all(t.action == Action.DESTROY for t in result)  # nosec
+
+
+def test_empty_locals_remote_prefixed_filesystem() -> None:
+    """Destroy remote-only snapshots keyed by the remote filesystem name."""
+    remote = filesystem("backup")
+    remote_snapshot_filesystem = filesystem("backup/pool/filesystem")
+    snapshot = Snapshot(
+        filesystem=remote_snapshot_filesystem,
+        name="snapshot",
+        previous=None,
+        timestamp=0,
+    )
+
+    result = generate(remote, {}, {remote_snapshot_filesystem: [snapshot]})
+
+    assert result == [  # nosec
+        Task(
+            action=Action.DESTROY,
+            filesystem=remote_snapshot_filesystem,
+            snapshot=snapshot,
+        ),
+        Task(
+            action=Action.DESTROY,
+            filesystem=remote_snapshot_filesystem,
+            snapshot=None,
+        ),
+    ]

--- a/zfs_test/replicate_test/task_test/generate_test.py
+++ b/zfs_test/replicate_test/task_test/generate_test.py
@@ -11,7 +11,7 @@ from zfs.replicate.filesystem import remote_filesystem
 from zfs.replicate.filesystem.type import FileSystem, filesystem
 from zfs.replicate.snapshot import Snapshot
 from zfs.replicate.task.generate import generate
-from zfs.replicate.task.type import Action
+from zfs.replicate.task.type import Action, Task
 from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 _REMOTE = filesystem("backup")
@@ -85,6 +85,32 @@ class TestGenerate:
             map(len, snapshots_by_fs.values()),
         )
         assert all(t.filesystem in snapshots_by_fs for t in result)
+
+    def test_empty_locals_remote_prefixed_filesystem(self) -> None:
+        """Destroy remote-only snapshots keyed by the remote filesystem name."""
+        remote = filesystem("backup")
+        remote_snapshot_filesystem = filesystem("backup/pool/filesystem")
+        snapshot = Snapshot(
+            filesystem=remote_snapshot_filesystem,
+            name="snapshot",
+            previous=None,
+            timestamp=0,
+        )
+
+        result = generate(remote, {}, {remote_snapshot_filesystem: [snapshot]})
+
+        assert result == [
+            Task(
+                action=Action.DESTROY,
+                filesystem=remote_snapshot_filesystem,
+                snapshot=snapshot,
+            ),
+            Task(
+                action=Action.DESTROY,
+                filesystem=remote_snapshot_filesystem,
+                snapshot=None,
+            ),
+        ]
 
     def test_diverged_destroys_before_sending(self) -> None:
         """Without a snapshot in common, the destroys precede the sends."""


### PR DESCRIPTION
Follow-up to #437 based on the remote-only filesystem failure surfaced after the SNAPSHOTS strategy started generating distinct filesystem names.

`generate()` was stripping the remote prefix from each `remote_snapshots` key in the cleanup loop, then using the stripped key to index the original `remote_snapshots` mapping. When local snapshots are empty and the remote mapping is keyed by `backup/pool/filesystem`, that lookup raises `KeyError` before the destroy tasks can be generated.

This keeps the original remote-prefixed key for the mapping lookup while still using the stripped local name to decide whether the filesystem is absent locally. It also adds a focused regression test for the `generate(remote, {}, remote_snapshots)` case.

Verification:
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. pytest -q -o addopts='' zfs_test/replicate_test/task_test/generate_test.py`