### PR TITLE
feat(cli): tune zfs send flags per invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Added
 
+- Send-side flags for `zfs send`, grouped under the `--send-` prefix and mirroring `--receive-`: `--send-large-block` passes `-L`, `--send-embed` passes `-e`, `--send-compressed` passes `-c`, `--send-props` passes `-p`, and `--send-raw / --send-no-raw` toggles `-w` (default on, for encrypted data sets) (#392).
 - Receive-side flags for `zfs receive`, grouped under the `--receive-` prefix: `--receive-force / --receive-no-force` toggles `-F` (default on), `--receive-mount / --receive-no-mount` toggles `-u` (default mounts), `--receive-resume-token-capable` passes `-s`, and the repeatable `--receive-set KEY=VALUE` maps to `-o KEY=VALUE` for properties such as `readonly`, `canmount`, or `mountpoint` on the replica without a post-receive patch-up (#393).
+
+### Changed
+
+- Renamed `--raw / --no-raw` (4.1.0) to `--send-raw / --send-no-raw` so every send flag shares the `--send-` prefix; the default still sends `zfs send -w` for encrypted data sets (#392).
+- `--follow-delete` no longer implies `zfs send -p`. Send properties are now controlled solely by `--send-props`; pass it alongside `--follow-delete` to keep the earlier behaviour (#392).
 
 ## 4.1.0 -- 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,9 @@ See `zfs-replicate --help` for the full set of `--receive-` flags.
 
 ## Tuning the send stream
 
-The `--send-` flags map onto `zfs send` properties of the stream. `--send-raw`
-(default) sends encrypted data sets without decryption; pass `--send-no-raw`
-when the destination can't preserve encryption. `--send-large-block`,
-`--send-embed`, and `--send-compressed` pass `-L`, `-e`, and `-c` so large
-blocks, embedded data, and already-compressed blocks replicate without being
-re-read or recompressed, and `--send-props` passes `-p` to carry data set
-properties in the stream. For example, to replicate a compressed, large-block
-data set whole:
+To replicate a large-block, already-compressed data set without re-reading or
+recompressing it on the way out, tune the `zfs send` stream with the `--send-`
+flags:
 
 ```bash
 zfs-replicate --send-large-block --send-compressed \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ zfs-replicate --receive-no-mount --receive-set readonly=on --receive-set canmoun
 
 See `zfs-replicate --help` for the full set of `--receive-` flags.
 
+## Tuning the send stream
+
+The `--send-` flags map onto `zfs send` properties of the stream. `--send-raw`
+(default) sends encrypted data sets without decryption; pass `--send-no-raw`
+when the destination can't preserve encryption. `--send-large-block`,
+`--send-embed`, and `--send-compressed` pass `-L`, `-e`, and `-c` so large
+blocks, embedded data, and already-compressed blocks replicate without being
+re-read or recompressed, and `--send-props` passes `-p` to carry data set
+properties in the stream. For example, to replicate a compressed, large-block
+data set whole:
+
+```bash
+zfs-replicate --send-large-block --send-compressed \
+  -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
+```
+
+See `zfs-replicate --help` for the full set of `--send-` flags.
+
 ## Documentation
 
 * `zfs-replicate --help`: Help for zfs-replicate.

--- a/zfs/replicate/cli/main.py
+++ b/zfs/replicate/cli/main.py
@@ -4,7 +4,7 @@ import itertools
 
 import click
 
-from .. import filesystem, receive, snapshot, ssh, task
+from .. import filesystem, receive, send, snapshot, ssh, task
 from ..compress import Compression
 from ..filesystem import FileSystem
 from ..filesystem import filesystem as filesystem_t
@@ -62,15 +62,7 @@ from .click import EnumChoice
     default=Compression.LZ4,
     help="One of: off (no compression), lz4 (fastest), pigz (all rounder), or plzip (best compression).",
 )
-@click.option(  # type: ignore[misc]
-    "--raw/--no-raw",
-    default=True,
-    help=(
-        "Pass --raw to zfs send so encrypted datasets replicate without"
-        " decryption (default). Use --no-raw to send decrypted data, for"
-        " example when the destination cannot preserve encryption."
-    ),
-)
+@options.send_group
 @options.receive_group
 @click.argument("host", required=True)  # type: ignore[misc]
 @click.argument("remote_fs", type=filesystem_t, required=True, metavar="REMOTE_FS")  # type: ignore[misc]
@@ -85,7 +77,7 @@ def main(  # pylint: disable=R0917,R0914,R0913
     identity_file: str,
     cipher: Cipher,
     compression: Compression,
-    raw: bool,
+    send_options: send.Options,
     receive_options: receive.Options,
     host: str,
     remote_fs: FileSystem,
@@ -145,9 +137,8 @@ def main(  # pylint: disable=R0917,R0914,R0913
         task.execute(
             remote_fs,
             filesystem_tasks,
-            follow_delete=follow_delete,
             compression=compression,
-            raw=raw,
+            send_options=send_options,
             receive_options=receive_options,
             ssh_command=ssh_command,
         )

--- a/zfs/replicate/cli/options.py
+++ b/zfs/replicate/cli/options.py
@@ -5,7 +5,92 @@ from typing import Callable, Dict, Tuple
 
 import click
 
-from .. import receive
+from .. import receive, send
+
+
+def send_group(command: Callable[..., None]) -> Callable[..., None]:
+    """Add the ``--send-*`` flag group to a Click command.
+
+    The decorated command must take a single ``send_options: send.Options``
+    parameter and must not declare the ``--send-*`` flags itself -- this owns
+    them and collapses them into that argument. Reach for this instead of
+    listing the flags inline, so they stay grouped and the ``--send-`` prefix
+    mirrors ``--receive-`` and keeps them from clashing with the global and
+    transport options.
+    """
+    command = click.option(
+        "--send-props",
+        "send_props",
+        is_flag=True,
+        help=(
+            "Pass -p to zfs send so the stream carries data set properties"
+            " such as compression and recordsize."
+        ),
+    )(command)
+    command = click.option(
+        "--send-compressed",
+        "send_compressed",
+        is_flag=True,
+        help=(
+            "Pass -c to zfs send so already-compressed blocks replicate"
+            " without being decompressed and recompressed."
+        ),
+    )(command)
+    command = click.option(
+        "--send-embed",
+        "send_embed",
+        is_flag=True,
+        help=(
+            "Pass -e to zfs send so embedded-data blocks (embedded_data"
+            " feature) replicate without being re-read from disk."
+        ),
+    )(command)
+    command = click.option(
+        "--send-large-block",
+        "send_large_block",
+        is_flag=True,
+        help=(
+            "Pass -L to zfs send so blocks larger than 128 KiB replicate"
+            " whole (requires the large_blocks feature on the destination)."
+        ),
+    )(command)
+    command = click.option(
+        "--send-raw/--send-no-raw",
+        "send_raw",
+        default=True,
+        help=(
+            "Pass -w (--raw) to zfs send so encrypted data sets replicate"
+            " without decryption (default). Use --send-no-raw to send"
+            " decrypted data, for example when the destination cannot"
+            " preserve encryption."
+        ),
+    )(command)
+
+    # Forwards every command parameter plus the five send flags, so the
+    # argument count is inherent to collapsing them into one kwarg.
+    @functools.wraps(command)
+    def wrapper(  # pylint: disable=R0913
+        *args: object,
+        send_large_block: bool,
+        send_raw: bool,
+        send_embed: bool,
+        send_compressed: bool,
+        send_props: bool,
+        **kwargs: object,
+    ) -> None:
+        return command(
+            *args,
+            send_options=send.Options(
+                large_block=send_large_block,
+                raw=send_raw,
+                embed=send_embed,
+                compressed=send_compressed,
+                props=send_props,
+            ),
+            **kwargs,
+        )
+
+    return wrapper
 
 
 def receive_group(command: Callable[..., None]) -> Callable[..., None]:

--- a/zfs/replicate/send/__init__.py
+++ b/zfs/replicate/send/__init__.py
@@ -1,0 +1,3 @@
+"""ZFS Send Operations."""
+
+from .type import Options as Options  # noqa: F401 # pylint: disable=C0414

--- a/zfs/replicate/send/type.py
+++ b/zfs/replicate/send/type.py
@@ -6,10 +6,25 @@ from typing import List
 
 @dataclass(frozen=True)
 class Options:
-    """Send-side settings, built by the CLI and read by ``snapshot._send``.
+    """Operator-tunable ``zfs send`` stream flags, one boolean per flag.
 
-    The defaults reproduce zfs-replicate's long-standing ``zfs send --raw``
-    behaviour, so a bare ``Options()`` means "nothing changes from before".
+    The CLI's ``--send-*`` group builds this and ``snapshot._send`` reads it
+    via :meth:`to_flags` to assemble the send command; construct one directly
+    only in tests. Defaults reproduce zfs-replicate's long-standing
+    ``zfs send -w`` behaviour, so a bare ``Options()`` changes nothing.
+
+    Each field enables a single ``zfs send`` flag:
+
+    - ``large_block`` (``-L``): send blocks larger than 128 KiB whole, rather
+      than splitting them -- needs the ``large_blocks`` feature on the
+      destination.
+    - ``raw`` (``-w``): send encrypted data sets without decrypting them.
+    - ``embed`` (``-e``): send embedded-data blocks as-is instead of reading
+      them back from disk -- needs the ``embedded_data`` feature.
+    - ``compressed`` (``-c``): send already-compressed blocks as stored,
+      skipping a decompress/recompress round trip.
+    - ``props`` (``-p``): carry data set properties (compression, recordsize,
+      and so on) in the stream.
     """
 
     large_block: bool = False
@@ -19,7 +34,13 @@ class Options:
     props: bool = False
 
     def to_flags(self) -> List[str]:
-        """Render these settings as ``zfs send`` flags (the caller adds ``-i``)."""
+        """Return the enabled options as ``zfs send`` tokens, e.g. ``["-L", "-w"]``.
+
+        Emits flags in a stable ``-L -w -e -c -p`` order and omits the
+        disabled ones. The structural ``-i previous`` (incremental source) is
+        deliberately absent: ``snapshot._send`` appends it, since only it
+        knows the previous snapshot.
+        """
         flags = []
 
         if self.large_block:

--- a/zfs/replicate/send/type.py
+++ b/zfs/replicate/send/type.py
@@ -1,0 +1,40 @@
+"""ZFS Send Type."""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class Options:
+    """Send-side settings, built by the CLI and read by ``snapshot._send``.
+
+    The defaults reproduce zfs-replicate's long-standing ``zfs send --raw``
+    behaviour, so a bare ``Options()`` means "nothing changes from before".
+    """
+
+    large_block: bool = False
+    raw: bool = True
+    embed: bool = False
+    compressed: bool = False
+    props: bool = False
+
+    def to_flags(self) -> List[str]:
+        """Render these settings as ``zfs send`` flags (the caller adds ``-i``)."""
+        flags = []
+
+        if self.large_block:
+            flags.append("-L")
+
+        if self.raw:
+            flags.append("-w")
+
+        if self.embed:
+            flags.append("-e")
+
+        if self.compressed:
+            flags.append("-c")
+
+        if self.props:
+            flags.append("-p")
+
+        return flags

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -8,6 +8,7 @@ from ..compress import Compression
 from ..error import ZFSReplicateError
 from ..filesystem import FileSystem
 from ..receive.command import command
+from ..send import Options as SendOptions
 from .type import Snapshot
 
 
@@ -19,13 +20,12 @@ def send(  # pylint: disable=R0917,R0913,R0914
     current: Snapshot,
     ssh_command: str,
     compression: Compression,
-    follow_delete: bool,
-    raw: bool,
+    send_options: SendOptions,
     receive_options: receive.Options,
     previous: Optional[Snapshot] = None,
 ) -> None:
     """Send ZFS Snapshot."""
-    send_command = _send(current, previous, follow_delete=follow_delete, raw=raw)
+    send_command = _send(current, previous, options=send_options)
 
     compress_command, decompress_command = compress.command(compression)
 
@@ -59,18 +59,12 @@ def send(  # pylint: disable=R0917,R0913,R0914
 def _send(
     current: Snapshot,
     previous: Optional[Snapshot] = None,
-    follow_delete: bool = False,
-    raw: bool = True,
+    *,
+    options: SendOptions,
 ) -> str:
-    options = []
-
-    if raw:
-        options.append("--raw")
-
-    if follow_delete:
-        options.append("-p")
+    flags = options.to_flags()
 
     if previous is not None:
-        options.append(f"-i '{previous.filesystem.name}@{previous.name}'")
+        flags.append(f"-i '{previous.filesystem.name}@{previous.name}'")
 
-    return f"/usr/bin/env - zfs send {' '.join(options)} '{current.filesystem.name}@{current.name}'"
+    return f"/usr/bin/env - zfs send {' '.join(flags)} '{current.filesystem.name}@{current.name}'"

--- a/zfs/replicate/task/execute.py
+++ b/zfs/replicate/task/execute.py
@@ -3,7 +3,7 @@
 import itertools
 from typing import List, Tuple
 
-from .. import filesystem, optional, receive, snapshot
+from .. import filesystem, optional, receive, send, snapshot
 from ..compress import Compression
 from ..filesystem import FileSystem
 from .type import Action, Task
@@ -13,9 +13,8 @@ def execute(  # pylint: disable=R0917,R0913
     remote: FileSystem,
     tasks: List[Tuple[FileSystem, List[Task]]],
     ssh_command: str,
-    follow_delete: bool,
     compression: Compression,
-    raw: bool,
+    send_options: send.Options,
     receive_options: receive.Options,
 ) -> None:
     """Execute all tasks."""
@@ -39,9 +38,8 @@ def execute(  # pylint: disable=R0917,R0913
                     remote,
                     a_tasks,
                     ssh_command=ssh_command,
-                    follow_delete=follow_delete,
                     compression=compression,
-                    raw=raw,
+                    send_options=send_options,
                     receive_options=receive_options,
                 )
 
@@ -63,9 +61,8 @@ def _send(  # pylint: disable=R0917,R0913
     remote: FileSystem,
     tasks: List[Task],
     ssh_command: str,
-    follow_delete: bool,
     compression: Compression,
-    raw: bool,
+    send_options: send.Options,
     receive_options: receive.Options,
 ) -> None:
     for task in tasks:
@@ -74,8 +71,7 @@ def _send(  # pylint: disable=R0917,R0913
             optional.value(task.snapshot),
             ssh_command=ssh_command,
             compression=compression,
-            follow_delete=follow_delete,
-            raw=raw,
+            send_options=send_options,
             receive_options=receive_options,
             previous=optional.value(task.snapshot).previous,
         )

--- a/zfs_test/replicate_test/cli_test/main_test.py
+++ b/zfs_test/replicate_test/cli_test/main_test.py
@@ -6,9 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 import zfs.replicate.cli.main as sut
-from zfs.replicate import receive
-from zfs.replicate.filesystem.type import filesystem
-from zfs.replicate.snapshot.send import _send
+from zfs.replicate import receive, send
 from zfs.replicate.snapshot.type import Snapshot
 
 
@@ -29,12 +27,12 @@ def test_invokes_without_stacktrace() -> None:
     ), "Expected SystemExit or FileNotFoundError."
 
 
-def test_no_raw_threads_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`--no-raw` reaches task.execute and the resulting send command omits --raw.
+def test_send_options_thread_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Send flags reach task.execute as the expected send.Options.
 
     .. code:: bash
 
-        zfs-replicate --no-raw -l alunduil -i mypy.ini example.com bogus bogus
+        zfs-replicate --send-no-raw --send-large-block --send-embed --send-compressed --send-props ...
     """
     captured: Dict[str, Any] = {}
 
@@ -55,7 +53,11 @@ def test_no_raw_threads_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:
     result = runner.invoke(
         sut.main,
         [
-            "--no-raw",
+            "--send-no-raw",
+            "--send-large-block",
+            "--send-embed",
+            "--send-compressed",
+            "--send-props",
             "-l",
             "alunduil",
             "-i",
@@ -66,12 +68,10 @@ def test_no_raw_threads_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:
         ],
     )
     assert result.exit_code == 0, result.output  # nosec
-    assert captured.get("raw") is False  # nosec
 
-    snapshot = Snapshot(
-        filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0
+    assert captured.get("send_options") == send.Options(  # nosec
+        large_block=True, raw=False, embed=True, compressed=True, props=True
     )
-    assert "--raw" not in _send(snapshot, raw=captured["raw"])  # nosec
 
 
 def test_receive_options_thread_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/zfs_test/replicate_test/send_test/__init__.py
+++ b/zfs_test/replicate_test/send_test/__init__.py
@@ -1,0 +1,1 @@
+"""Test send functionality."""

--- a/zfs_test/replicate_test/send_test/type_test.py
+++ b/zfs_test/replicate_test/send_test/type_test.py
@@ -1,0 +1,33 @@
+"""Test send options flag rendering."""
+
+import zfs.replicate.send.type as sut
+
+
+def test_to_flags_raws_by_default() -> None:
+    """Default options render only -w."""
+    assert sut.Options().to_flags() == ["-w"]  # nosec
+
+
+def test_to_flags_omits_raw_when_disabled() -> None:
+    """Disabling raw renders no flags."""
+    assert not sut.Options(raw=False).to_flags()  # nosec
+
+
+def test_to_flags_adds_large_block() -> None:
+    """Enabling large_block renders -L."""
+    assert "-L" in sut.Options(large_block=True).to_flags()  # nosec
+
+
+def test_to_flags_adds_embed() -> None:
+    """Enabling embed renders -e."""
+    assert "-e" in sut.Options(embed=True).to_flags()  # nosec
+
+
+def test_to_flags_adds_compressed() -> None:
+    """Enabling compressed renders -c."""
+    assert "-c" in sut.Options(compressed=True).to_flags()  # nosec
+
+
+def test_to_flags_adds_props() -> None:
+    """Enabling props renders -p."""
+    assert "-p" in sut.Options(props=True).to_flags()  # nosec

--- a/zfs_test/replicate_test/snapshot_test/send_test.py
+++ b/zfs_test/replicate_test/snapshot_test/send_test.py
@@ -1,27 +1,31 @@
 """zfs.replicate.snapshot.send tests."""
 
 from zfs.replicate.filesystem.type import filesystem
+from zfs.replicate.send.type import Options
 from zfs.replicate.snapshot.send import _send
 from zfs.replicate.snapshot.type import Snapshot
 
 
-def test_send_includes_raw_by_default() -> None:
-    """_send embeds --raw when raw is True."""
-    snapshot = Snapshot(
+def _snapshot() -> Snapshot:
+    return Snapshot(
         filesystem=filesystem("pool/data"),
         name="snap",
         previous=None,
         timestamp=0,
     )
-    assert "--raw" in _send(snapshot, raw=True)  # nosec
 
 
-def test_send_omits_raw_when_disabled() -> None:
-    """_send omits --raw when raw is False."""
-    snapshot = Snapshot(
-        filesystem=filesystem("pool/data"),
-        name="snap",
-        previous=None,
-        timestamp=0,
-    )
-    assert "--raw" not in _send(snapshot, raw=False)  # nosec
+def test_send_renders_enabled_flags() -> None:
+    """_send embeds the -X flag for each enabled send option."""
+    command = _send(_snapshot(), options=Options(large_block=True, props=True))
+
+    assert "-L" in command  # nosec
+    assert "-p" in command  # nosec
+
+
+def test_send_omits_disabled_flags() -> None:
+    """_send leaves out the -X flag for each disabled send option."""
+    command = _send(_snapshot(), options=Options(raw=False))
+
+    assert "-w" not in command  # nosec
+    assert "-L" not in command  # nosec


### PR DESCRIPTION
## Summary

Operators can now shape the `zfs send` stream from the CLI instead of being stuck with the hardcoded flags in `_send()`. A new `--send-` flag group exposes `--send-large-block`, `--send-embed`, `--send-compressed`, `--send-props`, and `--send-raw / --send-no-raw`, mirroring the `--receive-` group from #455.

Closes #392.

## Gotchas

- Two intentional behaviour changes (both in the CHANGELOG under Changed): `--raw / --no-raw` is **renamed** to `--send-raw / --send-no-raw` (old `--raw` dropped, not aliased), and `--follow-delete` **no longer implies `-p`** — send properties are now controlled solely by `--send-props`.
- The issue's literal acceptance criteria asked for short flags (`-L/-w/-e/-c/-p`); I went long-only under `--send-` instead, matching #455's stated intent ("symmetric prefixing to follow when send flags land") and because `-p` already aliases `--port`. Confirmed the convention with you before building.
- `send/` is a new top-level package holding only the `Options` value object — `_send` stays in `snapshot/send.py` per the issue, so unlike `receive/` there is no `send/command.py`.

## Verification

- 40 tests pass (32 prior + 8 new): per-flag `to_flags()` coverage, `_send` enabled/omitted flags, and a CLI integration test asserting all five `--send-*` flags reach `task.execute` as the expected `send.Options`.
- `pre-commit run --all-files` clean (black, isort, flake8, pylint, mypy, pydocstyle, vulture, vale).
- Rendered `--help`: the five `--send-*` options appear as a contiguous group, no short aliases, `--raw` gone.