### PR TITLE
ci: run pre-commit on pushes to master

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,9 +1,6 @@
 name: pre-commit
 
-on:
-  pull_request:
-  push:
-    branches: [main]
+on: [push, pull_request]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
## Summary
`pre-commit.yml`'s `push` trigger was scoped to `branches: [main]`, a stale ref from before the default branch settled on `master`. Drops the filter so it mirrors `pytest.yml`'s `on: [push, pull_request]`.

## Verification
- `main` no longer appears anywhere in `.github/workflows/` (was the only site)
- `on: [push, pull_request]` is valid YAML and matches the exact pattern already used in `pytest.yml`, `poetry.yml`, and `scripts.yml`

Closes #467