### PR TITLE
docs: add test-generation conventions for agents

### DIFF
--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -15,4 +15,5 @@ worked examples, and exceptions when a rule here doesn't fit the case.
 - Mock the process boundary `zfs.replicate.process.open`/`.run`, never real
   `zfs`/`ssh`. Test command builders on `Command.argv`/`.render()`.
 - Command line: `click.testing.CliRunner`.
-- Bug fix: add a regression test naming the issue in its docstring.
+- Bug fix: add a regression test whose docstring describes the behavior or
+  scenario and links the issue, not the issue alone.

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -4,8 +4,8 @@ Rules for generating a test. They're self-contained; consult
 [`docs/reference/testing.md`](../../docs/reference/testing.md) for rationale,
 worked examples, and exceptions when a rule here doesn't fit the case.
 
-- Path: `zfs/replicate/foo/bar.py` -> `zfs_test/replicate_test/foo_test/bar_test.py`;
-  `__init__.py` in each test package directory.
+- Test module mirrors the module under test, with `_test` appended to every
+  path segment; `__init__.py` in each test package directory.
 - Import the module under test as `sut`; end every `assert` with `# nosec`.
 - Domain-shaped inputs: `hypothesis.given` + strategies from the package's
   `strategies.py`. Fixed inputs only when a specific literal is the subject.

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -1,84 +1,22 @@
 # Test-generation conventions (AI agents)
 
-Tests run under `pytest` with `--doctest-modules --cov=zfs` (see
-[`pyproject.toml`](../../pyproject.toml)). The tree lives under `zfs_test/`.
-When you add code, add tests that mirror the patterns already in that tree
-rather than inventing new ones.
+Full conventions live in [`docs/reference/testing.md`](../../docs/reference/testing.md) -
+that document is the single source of truth for humans and agents alike. Read it first.
 
-## Layout
+## Shorthand for AI agents
 
-- Test files mirror the source path with a `_test` suffix on every segment:
-  `zfs/replicate/foo/bar.py` -> `zfs_test/replicate_test/foo_test/bar_test.py`.
-- Give each test package directory an `__init__.py` (some older directories
-  still lack one; follow the convention, don't copy the gaps).
-- Import the module under test as `sut`, not by re-exporting its symbols:
-  `import zfs.replicate.foo.bar as sut`.
-- `assert` statements carry a `# nosec` comment; bandit flags bare asserts and
-  this is the audited exception.
+When generating a test:
 
-## Property tests
+- Mirror the source path with a `_test` suffix on every segment:
+  `zfs/replicate/foo/bar.py` -> `zfs_test/replicate_test/foo_test/bar_test.py`,
+  with an `__init__.py` in each test package directory.
+- Import the module under test as `sut`; end every `assert` with `# nosec`.
+- For domain-shaped functions use `hypothesis.given` with strategies from the
+  package's `strategies.py`; reserve fixed inputs for a specific literal case.
+- Mock the process boundary (`zfs.replicate.process.open` / `process.run`),
+  never real `zfs`/`ssh`. Test command builders on `Command.argv`/`.render()`.
+- Drive the command line with `click.testing.CliRunner`.
+- On a bug fix, add a regression test naming the issue in its docstring.
 
-Prefer `hypothesis.given` with strategies over fixed inputs for functions whose
-domain has shape (snapshots, filesystems, timestamps). Reserve fixed inputs for
-cases where a specific literal is the point (a hostile string, a boundary flag).
-
-- Shared strategies live in `zfs_test/replicate_test/<pkg>_test/strategies.py`
-  and are imported by the tests in that package.
-- A typical property test:
-
-```python
-from hypothesis import given
-from hypothesis.strategies import lists
-
-from zfs.replicate.snapshot.list import _snapshots
-from zfs.replicate.snapshot.type import Snapshot
-from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
-
-
-@given(lists(SNAPSHOTS))  # type: ignore[misc]
-def test_snapshots(snapshots: list[Snapshot]) -> None:
-    """Round-trip the rendered list back through the parser."""
-    output = "\n".join(f"{s.filesystem.name}@{s.name}\t{s.timestamp}" for s in snapshots)
-    assert _snapshots(output.encode()) == snapshots  # nosec
-```
-
-## The process boundary
-
-`zfs/replicate/process.py` is the one place the project spawns a process
-(`process.open` for streaming/pipelines, `process.run` for run-to-completion).
-Never let a test shell out to real `zfs` or `ssh`.
-
-- Pure command *builders* (`*/command.py`) take no process; test them by
-  asserting on the returned `Command.argv` and `Command.render()` directly.
-- Code that *runs* a command mocks the boundary. Patch `zfs.replicate.process.run`
-  (or `.open`) with `monkeypatch.setattr` and return a fake
-  `subprocess.CompletedProcess` / `Popen`, so no external binary is invoked.
-
-## CLI tests
-
-Exercise the command line through `click.testing.CliRunner`. Patch the
-collaborators the command dispatches to, such as `snapshot.list` and
-`task.execute`, with `monkeypatch.setattr` and assert on `result.exit_code`,
-`result.output`, or captured arguments. A typical command-line test:
-
-```python
-import zfs.replicate.cli.main as sut
-from click.testing import CliRunner
-
-
-def test_set_rejects_malformed_property() -> None:
-    """`--receive-set` without an equals sign is rejected before execution."""
-    result = CliRunner().invoke(
-        sut.main,
-        ["--receive-set", "readonly", "-l", "alunduil", "-i", "mypy.ini",
-         "example.com", "bogus", "bogus"],
-    )
-    assert result.exit_code != 0  # nosec
-    assert "KEY=VALUE" in result.output  # nosec
-```
-
-## Regression tests
-
-When you fix a bug, add a test that fails before the fix and passes after, and
-link the issue in the test's docstring (for example, `Regression test for #123.`) so the
-motivation survives the diff.
+For the rationale, the worked examples, and the exceptions, follow the
+`docs/reference/testing.md` link above; don't duplicate them here.

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -1,22 +1,15 @@
-# Test-generation conventions (AI agents)
+# Test-generation conventions (agents)
 
-Full conventions live in [`docs/reference/testing.md`](../../docs/reference/testing.md) -
-that document is the single source of truth for humans and agents alike. Read it first.
+Rules for generating a test. They're self-contained; consult
+[`docs/reference/testing.md`](../../docs/reference/testing.md) for rationale,
+worked examples, and exceptions when a rule here doesn't fit the case.
 
-## Shorthand for AI agents
-
-When generating a test:
-
-- Mirror the source path with a `_test` suffix on every segment:
-  `zfs/replicate/foo/bar.py` -> `zfs_test/replicate_test/foo_test/bar_test.py`,
-  with an `__init__.py` in each test package directory.
+- Path: `zfs/replicate/foo/bar.py` -> `zfs_test/replicate_test/foo_test/bar_test.py`;
+  `__init__.py` in each test package directory.
 - Import the module under test as `sut`; end every `assert` with `# nosec`.
-- For domain-shaped functions use `hypothesis.given` with strategies from the
-  package's `strategies.py`; reserve fixed inputs for a specific literal case.
-- Mock the process boundary (`zfs.replicate.process.open` / `process.run`),
-  never real `zfs`/`ssh`. Test command builders on `Command.argv`/`.render()`.
-- Drive the command line with `click.testing.CliRunner`.
-- On a bug fix, add a regression test naming the issue in its docstring.
-
-For the rationale, the worked examples, and the exceptions, follow the
-`docs/reference/testing.md` link above; don't duplicate them here.
+- Domain-shaped inputs: `hypothesis.given` + strategies from the package's
+  `strategies.py`. Fixed inputs only when a specific literal is the subject.
+- Mock the process boundary `zfs.replicate.process.open`/`.run`, never real
+  `zfs`/`ssh`. Test command builders on `Command.argv`/`.render()`.
+- Command line: `click.testing.CliRunner`.
+- Bug fix: add a regression test naming the issue in its docstring.

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -7,8 +7,11 @@ worked examples, and exceptions when a rule here doesn't fit the case.
 - Test module mirrors the module under test, with `_test` appended to every
   path segment; `__init__.py` in each test package directory.
 - Import the module under test as `sut`; end every `assert` with `# nosec`.
-- Domain-shaped inputs: `hypothesis.given` + strategies from the package's
-  `strategies.py`. Fixed inputs only when a specific literal is the subject.
+- Checkable property over a shaped domain (round-trip, invariant, bound):
+  `hypothesis.given` + strategies from the package's `strategies.py`; pin a
+  must-run input with `@example`, don't split it into a separate test.
+- No property, or generation has cost/side effects (exact argv/render output, a
+  spawned process): plain fixed-input test, no Hypothesis.
 - Mock the process boundary `zfs.replicate.process.open`/`.run`, never real
   `zfs`/`ssh`. Test command builders on `Command.argv`/`.render()`.
 - Command line: `click.testing.CliRunner`.

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -1,0 +1,84 @@
+# Test-generation conventions (AI agents)
+
+Tests run under `pytest` with `--doctest-modules --cov=zfs` (see
+[`pyproject.toml`](../../pyproject.toml)). The tree lives under `zfs_test/`.
+When you add code, add tests that mirror the patterns already in that tree
+rather than inventing new ones.
+
+## Layout
+
+- Test files mirror the source path with a `_test` suffix on every segment:
+  `zfs/replicate/foo/bar.py` -> `zfs_test/replicate_test/foo_test/bar_test.py`.
+- Give each test package directory an `__init__.py` (some older directories
+  still lack one; follow the convention, don't copy the gaps).
+- Import the module under test as `sut`, not by re-exporting its symbols:
+  `import zfs.replicate.foo.bar as sut`.
+- `assert` statements carry a `# nosec` comment; bandit flags bare asserts and
+  this is the audited exception.
+
+## Property tests
+
+Prefer `hypothesis.given` with strategies over fixed inputs for functions whose
+domain has shape (snapshots, filesystems, timestamps). Reserve fixed inputs for
+cases where a specific literal is the point (a hostile string, a boundary flag).
+
+- Shared strategies live in `zfs_test/replicate_test/<pkg>_test/strategies.py`
+  and are imported by the tests in that package.
+- A typical property test:
+
+```python
+from hypothesis import given
+from hypothesis.strategies import lists
+
+from zfs.replicate.snapshot.list import _snapshots
+from zfs.replicate.snapshot.type import Snapshot
+from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
+
+
+@given(lists(SNAPSHOTS))  # type: ignore[misc]
+def test_snapshots(snapshots: list[Snapshot]) -> None:
+    """Round-trip the rendered list back through the parser."""
+    output = "\n".join(f"{s.filesystem.name}@{s.name}\t{s.timestamp}" for s in snapshots)
+    assert _snapshots(output.encode()) == snapshots  # nosec
+```
+
+## The process boundary
+
+`zfs/replicate/process.py` is the one place the project spawns a process
+(`process.open` for streaming/pipelines, `process.run` for run-to-completion).
+Never let a test shell out to real `zfs` or `ssh`.
+
+- Pure command *builders* (`*/command.py`) take no process; test them by
+  asserting on the returned `Command.argv` and `Command.render()` directly.
+- Code that *runs* a command mocks the boundary. Patch `zfs.replicate.process.run`
+  (or `.open`) with `monkeypatch.setattr` and return a fake
+  `subprocess.CompletedProcess` / `Popen`, so no external binary is invoked.
+
+## CLI tests
+
+Exercise the command line through `click.testing.CliRunner`. Patch the
+collaborators the command dispatches to, such as `snapshot.list` and
+`task.execute`, with `monkeypatch.setattr` and assert on `result.exit_code`,
+`result.output`, or captured arguments. A typical command-line test:
+
+```python
+import zfs.replicate.cli.main as sut
+from click.testing import CliRunner
+
+
+def test_set_rejects_malformed_property() -> None:
+    """`--receive-set` without an equals sign is rejected before execution."""
+    result = CliRunner().invoke(
+        sut.main,
+        ["--receive-set", "readonly", "-l", "alunduil", "-i", "mypy.ini",
+         "example.com", "bogus", "bogus"],
+    )
+    assert result.exit_code != 0  # nosec
+    assert "KEY=VALUE" in result.output  # nosec
+```
+
+## Regression tests
+
+When you fix a bug, add a test that fails before the fix and passes after, and
+link the issue in the test's docstring (for example, `Regression test for #123.`) so the
+motivation survives the diff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ issue.
 1. If not using Visual Studio Code, run `poetry shell`
 1. Run `pre-commit install` in your local checkout
 1. Make the changes in your fork
-1. Test your changes with `pytest`
+1. Test your changes with `pytest`, following the
+   [testing conventions](docs/reference/testing.md)
 1. Send your changes in a new pull request describing why you want to make that
    change
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -21,10 +21,16 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
 
 ## Property tests
 
-Functions whose domain has shape—snapshots, filesystems, timestamps—are
-exercised with `hypothesis.given` and strategies rather than fixed inputs. Fixed
-inputs cover cases where a specific literal is the subject, such as a hostile
-string or a single boundary flag.
+A function with a checkable property over a shaped domain—a round-trip, an
+invariant, a bound—uses `hypothesis.given` with strategies rather than
+hand-picked inputs. A specific input that must always run (a regression, a known
+edge) is pinned with `@example` on the property, not split into its own
+fixed-input test.
+
+Hypothesis is dropped where generation buys nothing: an assertion of exact
+output for one input (a rendered command, an `argv` list), or an input whose
+execution has cost or side effects (a spawned process). Those tests state their
+inputs as literals.
 
 Shared strategies for a package live in
 `zfs_test/replicate_test/<pkg>_test/strategies.py` and are imported by that

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -90,5 +90,6 @@ def test_set_rejects_malformed_property() -> None:
 
 ## Regression tests
 
-A bug fix adds a test that fails before the fix and passes after. The test's
-docstring names the issue it covers (for example, `Regression test for #123.`).
+A bug fix adds a test that fails before the fix and passes after. Its docstring
+describes the behavior or scenario under test and links the issue, not the issue
+alone (for example, `Rejects a snapshot name containing '@'; see #123.`).

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -6,9 +6,8 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
 
 ## Layout
 
-- A test file mirrors its source path with a `_test` suffix on every segment:
-  `zfs/replicate/foo/bar.py` has its tests in
-  `zfs_test/replicate_test/foo_test/bar_test.py`.
+- A test module mirrors the module under test, with `_test` appended to every
+  path segment, directories and file alike.
 - Each test package directory carries an `__init__.py`. Two older directories
   (`cli_test/`, `task_test/`) predate this and lack one; new directories add it.
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,0 +1,89 @@
+# Testing conventions
+
+The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
+`--doctest-modules --cov=zfs --cov-report=term-missing` (configured in
+[`pyproject.toml`](../../pyproject.toml)); `testpaths` is `zfs_test`.
+
+## Layout
+
+- A test file mirrors its source path with a `_test` suffix on every segment:
+  `zfs/replicate/foo/bar.py` has its tests in
+  `zfs_test/replicate_test/foo_test/bar_test.py`.
+- Each test package directory carries an `__init__.py`. Two older directories
+  (`cli_test/`, `task_test/`) predate this and lack one; new directories add it.
+
+## Imports and assertions
+
+- The module under test is imported as `sut`:
+  `import zfs.replicate.foo.bar as sut`. Tests reach into it through that alias
+  rather than re-exporting its symbols.
+- `assert` statements carry a trailing `# nosec`. Bandit flags bare asserts;
+  this is the audited exception for test code.
+
+## Property tests
+
+Functions whose domain has shape—snapshots, filesystems, timestamps—are
+exercised with `hypothesis.given` and strategies rather than fixed inputs. Fixed
+inputs cover cases where a specific literal is the subject, such as a hostile
+string or a single boundary flag.
+
+Shared strategies for a package live in
+`zfs_test/replicate_test/<pkg>_test/strategies.py` and are imported by that
+package's tests.
+
+```python
+from hypothesis import given
+from hypothesis.strategies import lists
+
+from zfs.replicate.snapshot.list import _snapshots
+from zfs.replicate.snapshot.type import Snapshot
+from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
+
+
+@given(lists(SNAPSHOTS))  # type: ignore[misc]
+def test_snapshots(snapshots: list[Snapshot]) -> None:
+    """Round-trip the rendered list back through the parser."""
+    output = "\n".join(f"{s.filesystem.name}@{s.name}\t{s.timestamp}" for s in snapshots)
+    assert _snapshots(output.encode()) == snapshots  # nosec
+```
+
+## The process boundary
+
+[`zfs/replicate/process.py`](../../zfs/replicate/process.py) is the sole place
+the project spawns a process: `process.open` for streaming and pipeline wiring,
+`process.run` for run-to-completion. Tests never spawn real `zfs` or `ssh`.
+
+- Command *builders* (`*/command.py`) construct a `Command` and spawn nothing.
+  Their tests assert on `Command.argv` and `Command.render()` directly.
+- Code that *runs* a command patches the boundary. A test replaces
+  `zfs.replicate.process.run` (or `process.open`) with `monkeypatch.setattr`,
+  returning a fake `subprocess.CompletedProcess` or `Popen`, so no external
+  binary runs.
+
+## Command-line tests
+
+The command line is exercised through `click.testing.CliRunner`. The
+collaborators a command dispatches to—`snapshot.list`, `task.execute`, and the
+like—are patched with `monkeypatch.setattr`; assertions read `result.exit_code`,
+`result.output`, or the arguments the fakes captured.
+
+```python
+import zfs.replicate.cli.main as sut
+from click.testing import CliRunner
+
+
+def test_set_rejects_malformed_property() -> None:
+    """`--receive-set` without an equals sign is rejected before execution."""
+    result = CliRunner().invoke(
+        sut.main,
+        ["--receive-set", "readonly", "-l", "alunduil", "-i", "mypy.ini",
+         "example.com", "bogus", "bogus"],
+    )
+    assert result.exit_code != 0  # nosec
+    assert "KEY=VALUE" in result.output  # nosec
+```
+
+## Regression tests
+
+A bug fix adds a test that fails before the fix and passes after. The test's
+docstring names the issue it covers (for example, `Regression test for #123.`).

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -1,4 +1,5 @@
 argparse
+docstring
 release-please
 semver
 subprocess


### PR DESCRIPTION
## Summary

Documents the repo's testing conventions as shared project documentation, so a contributor and a coding agent both write tests that fit: the `zfs_test/` layout (a test module mirrors the module under test, `_test` on every path segment), Hypothesis with strategies where a checkable property exists, the `zfs.replicate.process` boundary as the thing to mock instead of shelling out to real `zfs`/`ssh`, `CliRunner` for the command line, and a regression test whose docstring describes the behavior and links the issue.

The canonical reference is `docs/reference/testing.md` (a Diátaxis reference, with a worked property test and command-line test). CONTRIBUTING.md and `.github/copilot/test-generation.instructions.md` both point to it; the Copilot file carries only a terse agent shorthand. This mirrors how the commit-message conventions already work here — canonical text in one place, an instructions file as a pointer — so there's one source of truth rather than an agent-only copy.

Closes #425

## Gotchas

- The Copilot file lands in `.github/copilot/`, which isn't a path Copilot auto-loads; relocating it and scoping it with `applyTo` is deferred to #484. Content now, placement later.
- The issue named a `zfs.replicate.subprocess` boundary; that wrapper was renamed to `zfs.replicate.process` in 541bbc7 after the issue was filed, so the docs use the current module and its `open`/`run` functions.
- The `__init__.py` acceptance criterion isn't uniform in the tree — `cli_test/` and `task_test/` lack one. The reference states it as the convention and notes those predate it; fixing them is out of scope.
- The guidance recommends Hypothesis `@example` for pinning regression inputs, which the suite doesn't use yet — prescriptive by intent, not a description of current tests.
- Adds the repo's first `docs/` tree (committing to `docs/reference/`), plus `docstring` to the Vale vocabulary the new prose needs.

## Verification

- `pre-commit run vale` passes on all four changed files.
- Checked each documented convention against a real test: the property test (`snapshot_test/list_test.py` + `strategies.py`), the command-line test (`cli_test/main_test.py`), and the `process.open`/`process.run` boundary (`zfs/replicate/process.py`), so the reference describes what the suite actually does.