### PR TITLE
docs: add reusable pull request review checklist

### DIFF
--- a/.github/copilot/review.instructions.md
+++ b/.github/copilot/review.instructions.md
@@ -1,0 +1,61 @@
+# Pull request review checklist
+
+Measure every zfs-replicate pull request against this shared bar, whether the
+reviewer is a person or an AI assistant (Copilot review, Claude Code `/review`
+and `/code-review`). Apply it to the diff, not the whole tree: flag what the
+change introduces, not pre-existing debt it sits beside.
+
+Conventions this leans on live in [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+That document is the source of truth when the two disagree.
+
+## Correctness
+
+- Confirm new behaviour has tests under `zfs_test/` that fail without the change.
+- Confirm the change satisfies the linked issue's acceptance criteria.
+- Weigh the edge cases: empty input, a missing snapshot, an SSH or remote error,
+  a half-drained pipeline, and nonzero subprocess exit codes.
+
+## Safety
+
+- Reject any new `shell=True`, and any user input interpolated into a shell
+  string.
+- Require each new `# type: ignore` to name a specific error code
+  (`# type: ignore[code]`) and explain itself; refuse a blanket `# type: ignore`.
+  Hold `# nosec`, `# noqa`, and `pylint: disable` to the same bar.
+
+## Typing
+
+- Require PEP 604 unions (`X | None`) over `typing.Optional` or `typing.Union`.
+- Reject `Any` that lacks a justifying comment; keep `mypy --strict` green.
+- Require new domain types to be `@dataclass(frozen=True)`.
+
+## Process boundary
+
+- Route every child process through
+  [`zfs/replicate/process.py`](../../zfs/replicate/process.py), the one audited
+  `subprocess` boundary (argv list, `shell=False`). Nothing else imports
+  `subprocess` or calls `Popen`/`run` directly.
+
+## Logging
+
+- Send operational output through `logging.getLogger(__name__)`, never `print`
+  or a bare `click.echo`. The one sanctioned `click.echo` writes the final task
+  report to stdout; everything else is logging.
+
+## Command line
+
+- Update `--help` output for any new or changed option.
+- Preserve backward-compatible defaults unless the PR is explicitly a breaking
+  change (`!` marker plus a `BREAKING CHANGE:` footer -- see
+  [CONTRIBUTING.md](../../CONTRIBUTING.md#breaking-changes)).
+
+## Docs
+
+- Update the README for any new user-visible capability.
+- Read the `--help` text as someone who hasn't seen the option before, and
+  confirm it reads well.
+
+## Test plan
+
+- Confirm the PR states how the author verified the change, and that you can run
+  that plan locally (`poetry run pytest`, `pre-commit run --all-files`).

--- a/.github/copilot/review.instructions.md
+++ b/.github/copilot/review.instructions.md
@@ -5,6 +5,10 @@ reviewer is a person or an AI assistant (Copilot review, Claude Code `/review`
 and `/code-review`). Apply it to the diff, not the whole tree: flag what the
 change introduces, not pre-existing debt it sits beside.
 
+The pre-commit sensors run in CI (`black`, `isort`, `flake8`, `bandit`,
+`pylint`, `pydocstyle`, `mypy --strict`, and the blanket-ignore hooks). Assume
+they pass; this list covers only what they can't check.
+
 Conventions this leans on live in [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 That document is the source of truth when the two disagree.
 
@@ -15,26 +19,26 @@ That document is the source of truth when the two disagree.
 - Weigh the edge cases: empty input, a missing snapshot, an SSH or remote error,
   a half-drained pipeline, and nonzero subprocess exit codes.
 
-## Safety
+## Inline suppressions
 
-- Reject any new `shell=True`, and any user input interpolated into a shell
-  string.
-- Require each new `# type: ignore` to name a specific error code
-  (`# type: ignore[code]`) and explain itself; refuse a blanket `# type: ignore`.
-  Hold `# nosec`, `# noqa`, and `pylint: disable` to the same bar.
+- Require every new suppression -- `# type: ignore[code]`, `# nosec`, `# noqa`,
+  `pylint: disable` -- to say *why* in a comment. The hooks already force a
+  scoped code and reject a blanket ignore; the rationale is the reviewer's job.
 
 ## Typing
 
 - Require PEP 604 unions (`X | None`) over `typing.Optional` or `typing.Union`.
-- Reject `Any` that lacks a justifying comment; keep `mypy --strict` green.
+- Reject `Any` that lacks a justifying comment; `mypy --strict` permits explicit
+  `Any`, so this one falls to the reviewer.
 - Require new domain types to be `@dataclass(frozen=True)`.
 
 ## Process boundary
 
 - Route every child process through
   [`zfs/replicate/process.py`](../../zfs/replicate/process.py), the one audited
-  `subprocess` boundary (argv list, `shell=False`). Nothing else imports
-  `subprocess` or calls `Popen`/`run` directly.
+  `subprocess` boundary (argv list, `shell=False`). Any raw `subprocess` or
+  `Popen` trips bandit; the reviewer's job is confirming it belongs in
+  `process.py` and nowhere else.
 
 ## Logging
 

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -4,4 +4,5 @@ release-please
 semver
 stdout
 subprocess
+suppressions
 Zettabyte

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -1,5 +1,7 @@
 argparse
+argv
 release-please
 semver
+stdout
 subprocess
 Zettabyte


### PR DESCRIPTION
## Summary

zfs-replicate now has a checked-in review checklist at `.github/copilot/review.instructions.md`, so every pull request is judged against the same bar whether the reviewer is a person, Copilot review, or a Claude Code `/review` flow. The checklist deliberately covers only what the pre-commit sensors can't check — it assumes `black`, `isort`, `flake8`, `bandit`, `pylint`, `pydocstyle`, `mypy --strict`, and the pygrep blanket-ignore hooks are already green. Refs #423.

## Gotchas

- Two of the issue's acceptance criteria had drifted from the tree, so I followed the code rather than the assessment: the audited subprocess boundary is `zfs/replicate/process.py` (the AC said `subprocess.py`), and new `# type: ignore` carries a scoped error code plus a why-comment rather than a linked issue — the repo has no linked-issue precedent, only `# type: ignore[misc]`-style suppressions on third-party stubs.
- Three checklist items that restated a sensor were dropped or recast, so the list doesn't duplicate CI: `shell=True` is a bandit finding (removed; the shell-injection concern is structural, since `process.py` is argv-only with `shell=False`, and the process-boundary item now says so); "scoped code / no blanket ignore" is enforced by the pygrep hooks plus yesqa (the inline-suppressions item keeps only the why-comment); and "keep `mypy --strict` green" was a CI restatement (the typing item now explains why explicit `Any` still needs a comment, since strict permits it).
- The Typing section keeps the AC's "PEP 604 unions" wording verbatim, even though the `>=3.9` floor still uses `typing.Optional`/`Union` throughout (zero `X | None` in the tree, including the recent `process.py`). On 3.9 a runtime `X | None` annotation needs `from __future__ import annotations`, which the repo doesn't use. Worth a look because a reviewer applying this today could nit correct 3.9 code; the real migration lands with #398.
- AC #3 ("link from the PR template") is deferred: `.github/pull_request_template.md` belongs to #409 and doesn't exist yet. I've marked #423 blocked-by #409 and the "see review checklist" link lands when the template does — which is why this is `Refs #423`, not `Closes`.
- Added `argv`, `stdout`, and `suppressions` to the shared Vale vocabulary (`styles/config/vocabularies/ZFS/accept.txt`) so the checklist's technical terms pass prose lint.

## Verification

- `pre-commit run vale --files .github/copilot/review.instructions.md` passed after the vocabulary additions.
- Audited every checklist item against the configured sensors in `.pre-commit-config.yaml`, `.flake8` (bare — no flake8-print/bugbear), and `mypy.ini` (`strict`): confirmed the three dropped/recast items were the only ones a sensor already enforced, and that the survivors (`print`/`click.echo`, PEP 604, `frozen=True`, `--help`, defaults, docs, test plan) are not tool-checkable.
- Confirmed the checklist's claims match the tree: `zfs/replicate/process.py` is the only `subprocess`/`Popen` site, and `click.echo` appears only at `cli/main.py:125` (the final task report), consistent with the Logging item's one sanctioned exception.