### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,8 +1,9 @@
 name: Semantic Pull Request
 
-# Squash-merge lands the PR title as the commit on main, so the PR title is
-# what release-please parses. Validate it against the Conventional Commits
-# dialect documented in CONTRIBUTING.md.
+# Squash-merge lands the PR title as the commit on main, so the title—not the
+# individual commits—is what release-please parses for version bumps.
+# Keep the type list in sync with CONTRIBUTING and the conventional-pre-commit
+# hook.
 
 on:
   pull_request:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,37 @@
+name: Semantic Pull Request
+
+# Squash-merge lands the PR title as the commit on main, so the PR title is
+# what release-please parses. Validate it against the Conventional Commits
+# dialect documented in CONTRIBUTING.md.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            revert

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,11 +105,10 @@ repos:
           - shell
           - toml
           - yaml
-  # Local commit-msg mirror of the Semantic Pull Request CI check: authors see
-  # a bad type before pushing. Runs only at commit-msg stage, so it stays out
-  # of `pre-commit run` (CI, pre-commit.ci) and is bypassable with --no-verify;
-  # the CI PR-title check is the enforced gate. Keep types in sync with that
-  # workflow and the CONTRIBUTING commit-messages table.
+  # Advisory local mirror of the Semantic Pull Request workflow: catches a bad
+  # type at commit time. commit-msg stage keeps it out of `pre-commit run`, so
+  # it never becomes a CI gate and stays bypassable (--no-verify). Keep the
+  # type list in sync with that workflow and CONTRIBUTING.
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
 ci:
   autofix_prs: false
 repos:
@@ -102,3 +105,25 @@ repos:
           - shell
           - toml
           - yaml
+  # Local commit-msg mirror of the Semantic Pull Request CI check: authors see
+  # a bad type before pushing. Runs only at commit-msg stage, so it stays out
+  # of `pre-commit run` (CI, pre-commit.ci) and is bypassable with --no-verify;
+  # the CI PR-title check is the enforced gate. Keep types in sync with that
+  # workflow and the CONTRIBUTING commit-messages table.
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages:
+          - commit-msg
+        args:
+          - feat
+          - fix
+          - perf
+          - refactor
+          - docs
+          - test
+          - build
+          - ci
+          - chore
+          - revert


### PR DESCRIPTION
## Summary

PR titles are now CI-validated, so squash-merge lands a parseable subject on `main` and release-please can infer version bumps and changelog sections. Adds the Semantic Pull Request workflow plus a local `commit-msg` mirror for pre-push feedback.

Closes #416.

## Gotchas

- Allowed types match CONTRIBUTING (10, no `style`), not the issue's 11 — black/isort own formatting here, so a `style:` commit never occurs.
- Local hook is `commit-msg`-only: advisory, bypassable, never a CI gate — the workflow is the enforced check. (my read of the AC's "advisory, non-blocking")
- Two AC items aren't in this diff: branch-protection "required check" is a manual repo toggle post-merge; the CONTRIBUTING section already shipped in #424.

## Verification

- Hook accepts `feat(cli):` and scopeless `docs:`, rejects a non-conventional subject and `style:`.
- `pre-commit validate-config` and `check-yaml` pass on both files.