### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,35 @@
+# Validates that the pull request title follows Conventional Commits.
+#
+# Squash-merge makes the PR title the commit that lands on main, so this is
+# the gate release-please reads to infer the version bump and CHANGELOG entry.
+name: Semantic Pull Request
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # release-please defaults; keep in sync with CONTRIBUTING.md.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
   autofix_prs: false
+default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -102,3 +103,11 @@ repos:
           - shell
           - toml
           - yaml
+  # Advisory local check. Squash-merge discards individual commit messages, so
+  # the enforced gate is the PR-title workflow; this just surfaces the format
+  # early and is bypassable with `git commit --no-verify`.
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]


### PR DESCRIPTION
## Superseded by #487

#416 was implemented and merged independently in #487 while this branch was in
flight, so this PR is a duplicate — rebasing onto master collapses to an empty
diff. Closing unmerged.

The one piece of follow-up that survives is branch protection: making the
merged **Validate PR title** check a required status check is
infrastructure-as-code, tracked in alunduil/alunduil-infrastructure#209.

If the merged config's exclusion of the `style:` type (deliberate in #487, but
one short of the issue's 11-type list) turns out to be wrong, that's a small
follow-up against #487's result, not a reason to revive this branch.