### PR TITLE
ci: add OpenSSF Scorecard supply-chain analysis

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+# OpenSSF Scorecard analysis: grades the repo's supply-chain posture and
+# uploads the report to the Security tab. See https://github.com/ossf/scorecard.
+name: Scorecard supply-chain security
+
+on:
+  # Re-scan when branch protection settings change so the report stays current.
+  branch_protection_rule:
+  schedule:
+    - cron: '20 7 * * 1'
+  push:
+    branches: [master]
+
+# Read-only by default; the analysis job opts into the writes it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the results to the code-scanning dashboard (Security tab).
+      security-events: write
+      # Publish results to the OpenSSF API via keyless OIDC signing.
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '20 7 * * 1'
   push:
-    branches: [master]
+    branches: [main]
 
 # Read-only by default; the analysis job opts into the writes it needs.
 permissions: read-all

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 # zfs-replicate
 <!-- vale RedHat.Headings = YES -->
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/alunduil/zfs-replicate/badge)](https://securityscorecards.dev/viewer/?uri=github.com/alunduil/zfs-replicate)
+
 <https://github.com/alunduil/zfs-replicate>
 
 By Alex Brandt <alunduil@gmail.com>


### PR DESCRIPTION
## Summary

Adds an OpenSSF Scorecard analysis workflow so the repo's supply-chain posture is graded on a schedule instead of tracked from memory, and surfaces a badge for downstream packagers. Closes #414.

- `.github/workflows/scorecard.yml` runs `ossf/scorecard-action`, uploads SARIF to the Security tab, and publishes results to the OpenSSF API.
- Triggers on `branch_protection_rule`, a weekly cron, and `push` to `main`.
- Scorecard badge added at the top of the README.

## Blocked

**Blocked by #400** (default branch `main` across GitHub, CI, and bots). The push trigger targets `main` and only fires once the default branch is renamed; merging before then would ship a trigger that never runs. Hold this draft until #400 lands, at which point GitHub retargets this PR's base to `main`.

## Gotchas

- Actions are pinned by full commit SHA with version comments, following the official ossf starter template, so the workflow that grades pinning models the practice. This diverges from the other five workflows, which still use floating tags (`@v3`). Scorecard will flag those as an unpinned-dependencies finding; pinning them repo-wide is separate hardening work (see AC #5) — #418 tracks Renovate managing Action updates once pins land.
- The README badge URL is branch-agnostic (Scorecard analyzes whatever the default branch is), so only the workflow's push trigger references the branch name.

## Verification

- `pre-commit run --files .github/workflows/scorecard.yml README.md` passes (check-yaml, check-vcs-permalinks, vale).
- Action SHAs resolved from each project's release via `gh api`: `ossf/scorecard-action` v2.4.3, `actions/checkout` v7.0.0, `actions/upload-artifact` v7.0.1, `github/codeql-action` v3.37.0.
- Scorecard can only produce findings after the workflow runs on the default branch post-merge. AC #5 (review findings, cross-reference or file new issues) is a follow-up once the first SARIF lands. Expected mappings to existing siblings: Branch-Protection → #417, SAST → #413 (CodeQL), Security-Policy → #410, Pinned-Dependencies → new pinning issue.