### PR TITLE
ci(publish): use OIDC Trusted Publishing with attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   poetry:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC token for PyPI Trusted Publishing
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - name: install poetry
@@ -24,5 +28,5 @@ jobs:
           cache: poetry
       - name: poetry build
         run: poetry build
-      - name: poetry publish
-        run: poetry publish  --username __token__ --password=${{ secrets.PYPI_API_TOKEN }}
+      - name: publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Releases publish to PyPI without a long-lived `PYPI_API_TOKEN`: the job
now uses OIDC Trusted Publishing via `pypa/gh-action-pypi-publish`, so
PyPI issues a short-lived token scoped to this repo + workflow +
environment and the action emits PEP 740 provenance attestations by
default. `poetry build` still produces the sdist + wheel; the action
uploads from `dist/`.

## Gotchas

- Merging does **not** finish the switch — this is `Refs #412`, not
  `Closes`. Remaining steps:
  - PyPI Trusted Publisher for `alunduil/zfs-replicate` (workflow
    `publish.yml`, environment `pypi`) — done directly on PyPI (no
    Terraform provider for it).
  - The `pypi` GitHub Environment + @alunduil required reviewer is
    IaC-managed, tracked in alunduil/alunduil-infrastructure#212. It
    must exist before the next release or the OIDC exchange has no
    environment claim to bind against.
  - Remove the `PYPI_API_TOKEN` secret after the first successful OIDC
    release.
- `id-token: write` is granted at the job level only; the workflow
  default stays `contents: read`.

## Verification

- `pre-commit` (check-yaml among others) passes on the changed file.
- Publish path is only exercisable on a real `release: published`
  event, so end-to-end runs when the next release goes out.

Refs #412