### PR TITLE
chore: add CODEOWNERS to auto-route review to @alunduil

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Solo-maintained: route review on every path to @alunduil.
+# The last matching pattern wins, so add path-specific overrides below.
+* @alunduil


### PR DESCRIPTION
## Summary

Non-owner PRs now auto-request review from @alunduil instead of waiting on a manual tag. A single catch-all `.github/CODEOWNERS` rule (`* @alunduil`) drives GitHub's Code Owners routing and stays correct if co-maintainers later add path-specific overrides below it.

Closes #411

## Gotchas

- This PR covers only the CODEOWNERS file (AC #1). Making Code Owner review a required merge gate and confirming the auto-request (AC #2/#3) is branch-protection config, which is managed as IaC in alunduil-infrastructure — tracked there in alunduil/alunduil-infrastructure#210, not doable from this repo.
- The issue text says protect `main`; this repo's default branch is `master`. CODEOWNERS is branch-agnostic, so the file is unaffected; the ruleset (issue #210) attaches to `master` and coordinates with the pending `master`->`main` rename decision.