### PR TITLE
docs: add security policy and disclosure path

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,14 @@ See `zfs-replicate --help` for the full set of `--send-` flags.
 ## Getting support
 
 * [GitHub issues]: Report any problems or features requests to GitHub issues.
+* [Security policy]: Report a security vulnerability privately.
 
 [autorepl.py]: https://github.com/freenas/freenas/blob/master/gui/tools/autorepl.py
 [FreeBSD]: https://www.freebsd.org/
 [`FreeNAS`]: http://www.freenas.org/
 [GitHub issues]: https://github.com/alunduil/zfs-replicate/issues
 [LICENSE]: ./LICENSE
+[Security policy]: ./SECURITY.md
 [sanoid]: https://github.com/jimsalterjrs/sanoid
 [survey]: https://www.reddit.com/r/zfs/comments/7fqu1y/a_small_survey_of_zfs_remote_replication_tools/
 [Working With Oracle Solaris ZFS Snapshots and Clones]: https://docs.oracle.com/cd/E26505_01/html/E37384/gavvx.html#scrolltoc

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security policy
+
+## Supported versions
+
+`zfs-replicate` follows [semantic versioning](https://semver.org/). Security
+fixes land on the most recent release in the current major series. Earlier
+major series receive no fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| 4.x     | Yes       |
+| < 4.0   | No        |
+
+## Reporting a vulnerability
+
+Report security vulnerabilities privately rather than opening a public issue.
+
+- Preferred: use GitHub's [private vulnerability reporting][advisory], the
+  "Report a vulnerability" button on the repository's Security tab. Reports stay
+  private to the maintainer until I publish an advisory.
+- Alternative: email Alex Brandt at <alunduil@gmail.com>.
+
+Include the affected version, a description of the issue, and, if you can, the
+steps or input needed to reproduce it. `zfs-replicate` invokes `ssh` and `zfs`
+with user-supplied host names and data set names, so reproduction details for
+that surface help the most.
+
+## What to expect
+
+This is a single-maintainer project, so responses are best-effort. Expect an
+acknowledgment within a couple of weeks. Once I confirm a report, I ship a fix
+and publish an advisory as soon as is practical.
+
+## Credit
+
+I credit reporters in the advisory and release notes by default. Say so in your
+report if you would rather remain anonymous.
+
+[advisory]: https://github.com/alunduil/zfs-replicate/security/advisories/new


### PR DESCRIPTION
## Summary

Security researchers now have a documented private disclosure path instead of a public issue on a tool that shells out to `ssh`/`zfs`. Adds `SECURITY.md` (supported versions, private reporting channels, best-effort response expectations, credit-by-default) and links it from the README's "Getting support" section.

Delivers two of the three acceptance criteria in #410 (the `SECURITY.md` file and the README link). The third — enabling GitHub private vulnerability reporting — is IaC-managed and tracked in alunduil/alunduil-infrastructure#211, which #410 is now blocked by. This PR references #410 rather than closing it; #410 closes once the IaC change lands.

Refs #410

## Gotchas

- The policy names GitHub private vulnerability reporting as the preferred channel, but that button only exists once the repo setting is on. Enabling it is out of scope here (IaC-managed, alunduil/alunduil-infrastructure#211); until it lands, the email fallback carries disclosure.
- Response-time wording is a deliberate soft target ("within a couple of weeks", best-effort) rather than a hard SLA — solo project, overpromising is worse than honest.

## Verification

- \`pre-commit run --files SECURITY.md README.md\` passed, including Vale (rewrote to clear its passive-voice, contraction, and RedHat term rules).