### PR TITLE
chore: add outcome-oriented feature-request issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions / support
+    url: https://github.com/alunduil/zfs-replicate#getting-support
+    about: For usage questions and support, see the getting-support section of the README.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest a capability you'd like zfs-replicate to make possible.
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the desired outcome, not the task. A good title
+        names the problem you're trying to solve rather than a specific
+        implementation you'd like bolted on.
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User story
+      description: Who wants this, what capability, and to what end?
+      placeholder: As a ___, I want ___, so that ___.
+    validations:
+      required: true
+  - type: textarea
+    id: current-workaround
+    attributes:
+      label: Current workaround
+      description: How do you accomplish this today, if at all?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you set them aside.
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria draft
+      description: How would we know this is done? A checklist is welcome.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,40 +1,40 @@
+---
 name: Feature request
 description: Suggest a capability you'd like zfs-replicate to make possible.
-labels:
-  - enhancement
+labels: [enhancement]
 body:
   - type: markdown
     attributes:
-      value: |
-        Please describe the desired outcome, not the task. A good title
-        names the problem you're trying to solve rather than a specific
-        implementation you'd like bolted on.
+      value: >-
+        Describe the desired outcome, not the task. A good title names the
+        problem you're trying to solve rather than a specific implementation
+        you'd like bolted on.
+
   - type: textarea
     id: user-story
     attributes:
       label: User story
-      description: Who wants this, what capability, and to what end?
+      description: Name who wants this, the capability, and the outcome it serves.
       placeholder: As a ___, I want ___, so that ___.
     validations:
       required: true
+
   - type: textarea
     id: current-workaround
     attributes:
       label: Current workaround
-      description: How do you accomplish this today, if at all?
-    validations:
-      required: false
+      description: Describe how you accomplish this today, if at all.
+
   - type: textarea
     id: alternatives-considered
     attributes:
       label: Alternatives considered
-      description: Other approaches you weighed and why you set them aside.
-    validations:
-      required: false
+      description: List other approaches you weighed and why you set them aside.
+
   - type: textarea
     id: acceptance-criteria
     attributes:
       label: Acceptance criteria draft
-      description: How would we know this is done? A checklist is welcome.
-    validations:
-      required: false
+      description: >-
+        Describe how we would know this is done. A task list (- [ ]) is
+        welcome.


### PR DESCRIPTION
## Summary

Feature requests filed through GitHub's chooser now prompt for the Patton user-story shape (role + capability + outcome) instead of an empty box, so requests describe the problem to solve rather than a specific implementation. Adds `feature-request.yml` (auto-labels `enhancement`) and the `ISSUE_TEMPLATE/config.yml` that carries the chooser's support link. Closes #408.

## Gotchas

- The form follows the dungeon-studio issue-form house style (folded scalars, active-voice descriptions), but deliberately omits the SPDX header those files carry: this repo uses no SPDX/REUSE headers and is `BSD-2-Clause`, not MIT.
- Discussions are disabled on this repo, so the "Questions / support" contact link points at the README `#getting-support` anchor rather than a Discussions category, per the issue's fallback.
- `blank_issues_enabled: true` for now — there's no bug template yet, so forcing every issue through the feature form would misroute bug reports. The bug form (#407) flips this to `false` once it lands.
- GitHub's issue-form schema can't be validated locally; the YAML parses and pre-commit passes, but the actual form rendering only shows up once it's on the default branch.

Closes #408