### PR TITLE
ci: cancel superseded runs via concurrency groups

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+# No cancel-in-progress: a publish cancelled mid-upload can leave PyPI in a
+# partial state.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   poetry:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate PR title


### PR DESCRIPTION
## Summary

Redundant CI runs now cancel themselves when a newer commit lands on the
same ref, so capacity isn't spent on superseded matrix runs. #497's
consolidation already gave `ci.yml` a concurrency block, so this fills in
the two workflows it left uncovered: `semantic-pull-request.yml` and
`publish.yml`.

Closes #402

## Gotchas

- `publish.yml` intentionally omits `cancel-in-progress` — cancelling a
  PyPI upload mid-flight can leave a partial release. It gets the group
  only.
- `semantic-pull-request.yml` fires only on `pull_request`, so its ref is
  never `master`; unconditional `cancel-in-progress: true` is safe there.
  `ci.yml`'s existing conditional (spare master pushes) is left as-is.

## Test plan

- `pre-commit run --files …` on both workflows: check-yaml passed.