### PR TITLE
ci: replace Dependabot with Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,13 @@ repos:
           - shell
           - toml
           - yaml
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.270.0
+    hooks:
+      - id: renovate-config-validator
+        args:
+          - --strict
+          - --no-global
   # Advisory local mirror of the Semantic Pull Request workflow: catches a bad
   # type at commit time. commit-msg stage keeps it out of `pre-commit run`, so
   # it never becomes a CI gate and stays bypassable (--no-verify). Keep the

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,12 @@
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "vulnerabilityAlerts": {"minimumReleaseAge": "0 days"},
-  "osvVulnerabilityAlerts": true
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "Exempt update types that carry no release timestamp from the minimum release-age bake, so their renovate/stability-days check can resolve under internalChecksFilter:strict",
+      "matchUpdateTypes": ["pin", "pinDigest", "digest", "lockFileMaintenance"],
+      "minimumReleaseAge": "0 days"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", "schedule:weekly"],
+  "baseBranchPatterns": ["master"],
+  "reviewers": ["alunduil"],
+  "pre-commit": {"enabled": true},
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": {"minimumReleaseAge": "0 days"},
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
## Summary

Dependabot's one-package-at-a-time bumps keep landing on versions the `dependency-review` gate rejects. #469 bumps pytest to 8.4.2, still inside the GHSA-6w46-j5rx-g56g advisory window (patched only in 9.0.3, above our `<9.0` pin), so it can't go green. Renovate replaces it for grouping, a release-bake period, and OSV-backed vulnerability alerts that fit this Poetry project better.

Removes `.github/dependabot.yml`, adds `renovate.json` on `config:best-practices` with weekly scheduling, a 3-day `minimumReleaseAge` bake carved out for security alerts, and the pre-commit manager. Wires `renovate-config-validator` into pre-commit so schema drift fails at commit time.

## Gotchas

- The `minimumReleaseAge` bake plus `internalChecksFilter: strict` would silently suppress every update type that carries no release timestamp — `digest`, `pinDigest`, `pin`, `lockFileMaintenance` — because their `renovate/stability-days` check can never resolve. Since `config:best-practices` pins GitHub Action digests, that's the common case here. A `packageRules` carve-out (`minimumReleaseAge: 0`) exempts them, matching the `alunduil-chezmoi` and `genshin.dungeon.studio` configs.
- Reactivation depends on the Renovate GitHub App still being installed on the account. Its onboarding PR (#389) was closed unmerged, so this config on `master` is what re-onboards it — but if the App was uninstalled, the file is inert until it's reinstalled. That's a repo-settings/IaC action this PR can't perform.
- This does not fix the pytest advisory itself: the `pytest = ">=7.2,<9.0"` pin in `pyproject.toml` forbids the patched 9.0.3, so `dependency-review` will keep flagging any pytest bump until that constraint is loosened — a separate change.
- Closing #469 (Dependabot's last open PR) belongs with this migration.

## Test plan

- `pre-commit run renovate-config-validator --files renovate.json` → Passed (valid under `--strict --no-global`).
- Full `pre-commit` run on the commit → all hooks Passed.

Refs #469