### PR TITLE
docs: record ADR for parallel-replication scheduler

### DIFF
--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -28,9 +28,10 @@ form. A record whose weight lies in comparing options uses
 and their trade-offs stand as their own sections rather than dissolving
 into prose.
 
-Every record starts at `Proposed`. It moves to `Accepted` after the team
-commits to the decision, or to `Superseded by NNNN` or `Deprecated` when
-a later record replaces it.
+A record merges into the default branch as `Accepted`: reaching the
+default branch is the decision, and review and dissent happen on the
+pull request beforehand. A later record moves an earlier one to
+`Superseded by NNNN` or `Deprecated`.
 
 ## Consequences
 

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -36,7 +36,6 @@ pull request beforehand. A later record moves an earlier one to
 ## Consequences
 
 The rationale behind a hard choice survives next to the code it governs,
-and a new contributor reads the collection in sequence to see how the
-current design took shape. The cost is discipline: writing a record when
-a decision warrants one, and the judgment to skip the rest. A collection
-padded with tactical notes is worth less than a spare one.
+and a new contributor reads the collection to see how the current design
+took shape. The cost is discipline: writing a record when a decision
+warrants one, and the judgment to skip the rest.

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -1,0 +1,41 @@
+# 0. Record architecture decisions
+
+## Status
+
+Proposed
+
+## Context
+
+An architecturally significant decision -- one that sets precedent,
+locks in a dependency, shapes an interface, or picks between non-trivial
+options -- loses its rationale after it lands as code. A diff shows what
+changed. It doesn't record which options lost out, or why. Months later
+a reader rebuilds that reasoning from memory or argues it again from
+scratch.
+
+## Decision
+
+This repository keeps Architecture Decision Records under `docs/adr/`,
+one file per decision, named `NNNN-kebab-title.md` with a zero-padded
+sequence. A record earns its place when a decision both sets direction
+and resists reversal. Tactical, reversible choices stay in commit
+messages and pull request descriptions.
+
+This meta-record uses the short
+[Nygard](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+form. A record whose weight lies in comparing options uses
+[MADR](https://adr.github.io/madr/) instead, so the considered options
+and their trade-offs stand as their own sections rather than dissolving
+into prose.
+
+Every record starts at `Proposed`. It moves to `Accepted` after the team
+commits to the decision, or to `Superseded by NNNN` or `Deprecated` when
+a later record replaces it.
+
+## Consequences
+
+The rationale behind a hard choice survives next to the code it governs,
+and a new contributor reads the collection in sequence to see how the
+current design took shape. The cost is discipline: writing a record when
+a decision warrants one, and the judgment to skip the rest. A collection
+padded with tactical notes is worth less than a spare one.

--- a/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
+++ b/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context and Problem Statement
 

--- a/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
+++ b/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
@@ -8,8 +8,11 @@ Accepted
 
 `task/execute.py` replicates filesystems one at a time. For an operator
 with many independent data sets, a run takes the sum of the times for
-every data set rather than the time of the slowest one (issue #394, and
-the original request in #3). The data sets are independent: their send
+every data set rather than the time of the slowest one (issue
+[#394](https://github.com/alunduil/zfs-replicate/issues/394), and the
+original request in
+[#3](https://github.com/alunduil/zfs-replicate/issues/3)). The data sets
+are independent: their send
 and receive pipes share no ordering constraint.
 
 The tasks reaching `execute()` still carry ordering constraints, but the
@@ -84,8 +87,9 @@ valid topological order that reproduces the sequential path.
 
 Tests cover the sequential path (`--jobs 1`) and the parallel path
 (`--jobs 4`) reaching the same final state, and a failing data set that
-leaves the others to finish while the run exits nonzero (the issue #394
-acceptance criteria).
+leaves the others to finish while the run exits nonzero (the
+[#394](https://github.com/alunduil/zfs-replicate/issues/394) acceptance
+criteria).
 
 ## Pros and Cons of the Options
 
@@ -142,7 +146,8 @@ waiting for the whole level before the next starts.
 
 ## More Information
 
-Issue #394 carries the acceptance criteria and the `--jobs` flag. The
-dependency on operational output flowing through the logging module
-(issue #434) landed first, so log records stay one line under
-concurrency.
+Issue [#394](https://github.com/alunduil/zfs-replicate/issues/394)
+carries the acceptance criteria and the `--jobs` flag. The dependency on
+operational output flowing through the logging module (issue
+[#434](https://github.com/alunduil/zfs-replicate/issues/434)) landed
+first, so log records stay one line under concurrency.

--- a/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
+++ b/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
@@ -1,0 +1,148 @@
+# 1. Schedule parallel replication with a task dependency graph
+
+## Status
+
+Proposed
+
+## Context and Problem Statement
+
+`task/execute.py` replicates filesystems one at a time. For an operator
+with many independent data sets, a run takes the sum of the times for
+every data set rather than the time of the slowest one (issue #394, and
+the original request in #3). The data sets are independent: their send
+and receive pipes share no ordering constraint.
+
+The tasks reaching `execute()` still carry ordering constraints, but the
+current code encodes them by accident. `generate.py` emits a `CREATE`
+task keyed by the destination filesystem and a run of `SEND` tasks keyed
+by the remote root, so the create for a single data set and its sends
+land in separate groups. A sort by name depth then happens to order
+create before send. That accidental ordering is what breaks under
+unguarded parallelism: a `SEND` can start before its `CREATE` finishes.
+
+The question is how to run independent data sets concurrently while
+honoring the ordering that the depth sort now hides.
+
+## Decision Drivers
+
+* Correctness: the create for a data set precedes its sends, a child's
+  create follows its parent's, the incremental sends for a data set stay
+  in order, and a child's destroy precedes its parent's.
+* `--jobs 1` reproduces today's sequential behavior.
+* One failed data set leaves the others running, and the run exits
+  nonzero at the end.
+* The smallest amount of custom concurrency code that stays correct, so
+  the sequential and parallel paths stay testable.
+* A ready task starts as soon as its own dependencies finish, not at a
+  batch boundary.
+
+## Considered Options
+
+* A -- Self-scheduling queue, readiness carried on the message
+* B -- Coordinator thread with separate ready and done queues
+* C -- Main-thread dispatcher over a bounded `ThreadPoolExecutor`
+* D -- Topological levels with a barrier between each
+
+## Decision Outcome
+
+Chosen option: **C, a main-thread dispatcher over a bounded
+`ThreadPoolExecutor`**, because it states the ordering constraints as an
+explicit dependency graph and lets the executor and `futures.wait` stand
+in for a hand-built ready queue, which drops the coordinator thread, the
+poison-pill shutdown, and the shared-state locking that the other
+options carry.
+
+An edge builder derives the graph from the tasks once, up front, from
+four rules: create-before-send within a data set,
+parent-create-before-child-create, send-before-send along the snapshot
+chain for a data set, and child-destroy-before-parent-destroy. A `SEND`
+task takes its data set identity from its snapshot rather than its task
+key, since `generate.py` keys sends by the remote root.
+
+The dispatcher runs on the main thread. It submits every task whose
+in-degree is zero, waits for the first future to finish, decrements the
+in-degree of that task's dependents, and submits any that reach zero. It
+repeats until no futures remain. `ThreadPoolExecutor(max_workers=N)` from
+`--jobs N` bounds concurrency, and `--jobs 1` collapses the graph to one
+valid topological order that reproduces the sequential path.
+
+### Consequences
+
+* Good: the ordering rules become explicit data instead of a fragile
+  sort key, so a reader sees why each task waits.
+* Good: independent data sets run as soon as they're ready, up to the
+  job limit, with no batch barrier.
+* Good: all graph bookkeeping stays on the main thread, so no lock
+  guards the shared state, and the loop ends when the last future
+  drains, without poison pills.
+* Bad: the edge builder and dispatcher add code and test surface that
+  the sequential loop never needed.
+* Neutral: the depth sort that ordered tasks before goes away, replaced
+  by the explicit edges.
+
+### Confirmation
+
+Tests cover the sequential path (`--jobs 1`) and the parallel path
+(`--jobs 4`) reaching the same final state, and a failing data set that
+leaves the others to finish while the run exits nonzero (the issue #394
+acceptance criteria).
+
+## Pros and Cons of the Options
+
+### A -- Self-scheduling queue, readiness on the message
+
+Every task sits on one queue. A worker pulls a task, checks whether its
+dependencies have finished, runs it when they have, and pushes it back
+when they haven't.
+
+* Good: one queue, little structure.
+* Bad: a not-ready task cycles through the queue again and again, which
+  burns cycles and needs a delay to avoid a busy spin.
+* Bad: workers share the completion state, so a lock guards it.
+* Bad: ordering emerges from the churn rather than from a stated rule,
+  which is hard to reason about.
+
+### B -- Coordinator thread with ready and done queues
+
+A coordinator owns the in-degree map. It pushes ready tasks to a ready
+queue, workers run them and report identifiers back on a done queue, and
+the coordinator drains the done queue to release dependents.
+
+* Good: workers hold no state, and one place owns the graph.
+* Bad: a long-lived coordinator thread, two queues, and poison-pill
+  shutdown add moving parts.
+* Bad: the "queue empty but work still in flight" termination check is a
+  classic place to get shutdown subtly wrong.
+
+This sits close to the shape the issue implicitly describes -- the
+current sequential loop with a coordinator around it -- but option C
+reaches the same behavior without the extra thread or the queues.
+
+### C -- Main-thread dispatcher over a bounded `ThreadPoolExecutor`
+
+The chosen option. The executor's internal queue serves as the ready
+holding area, and `futures.wait(FIRST_COMPLETED)` serves as the waiter,
+so the dispatcher stays a single main-thread loop.
+
+* Good: no coordinator thread, no hand-built queue, no poison pills.
+* Good: graph mutation stays on the main thread, so no lock.
+* Good: `--jobs 1` gives a bounded pool of one and a strict topological
+  order without extra work.
+* Bad: failure handling -- skipping the dependents of a failed task --
+  lives in the loop rather than in a framework.
+
+### D -- Topological levels with a barrier
+
+Group tasks into dependency levels and run each level as a batch,
+waiting for the whole level before the next starts.
+
+* Good: the fewest moving parts, one `executor.map` per level.
+* Bad: the barrier wastes parallelism, since a task that depends on one
+  fast neighbor still waits for the slowest task in its level.
+
+## More Information
+
+Issue #394 carries the acceptance criteria and the `--jobs` flag. The
+dependency on operational output flowing through the logging module
+(issue #434) landed first, so log records stay one line under
+concurrency.

--- a/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
+++ b/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
@@ -7,29 +7,22 @@ Accepted
 ## Context and Problem Statement
 
 `task/execute.py` replicates filesystems one at a time, so a run's total
-time is the sum of the times for every data set. The data sets are
-independent: their send and receive pipes share no ordering constraint,
-and running them concurrently trims that time. The gain stays bounded
-rather than unlimited: `--jobs N` caps concurrency at N workers,
-and a single data set stays serial, since its create precedes its sends
-and its incremental sends run in order. By Amdahl's law the speedup
-tracks the parallel fraction and the worker count. The floor is the
-longest single data set plus the serial work every run shares -- listing
-snapshots, creating the destination root, and planning the tasks. Issue
+time is the sum across every data set. Independent data sets could run
+concurrently -- their send and receive pipes share no ordering
+constraint -- bounded by `--jobs N` and by the longest single data set,
+since each stays serial internally (create before sends, sends in
+order). Issue
 [#394](https://github.com/alunduil/zfs-replicate/issues/394) targets
-this, drawing on the original request in
+this, from the original request in
 [#3](https://github.com/alunduil/zfs-replicate/issues/3).
 
 The tasks reaching `execute()` still carry ordering constraints, but the
-current code encodes them by accident. `generate.py` emits a `CREATE`
-task keyed by the destination filesystem and a run of `SEND` tasks keyed
-by the remote root, so the create for a single data set and its sends
-land in separate groups. A sort by name depth then happens to order
-create before send. That accidental ordering is what breaks under
-unguarded parallelism: a `SEND` can start before its `CREATE` finishes.
-
-The question is how to run independent data sets concurrently while
-honoring the ordering that the depth sort now hides.
+current code encodes them incidentally: `generate.py` keys a `CREATE` by
+its destination filesystem and the following `SEND`s by the remote root,
+so the create for a data set and its sends land in separate groups, and
+only a sort by name depth places create before send. Unguarded
+parallelism breaks that: a `SEND` can start before its `CREATE`
+finishes.
 
 ## Decision Drivers
 
@@ -39,8 +32,7 @@ honoring the ordering that the depth sort now hides.
 * `--jobs 1` reproduces today's sequential behavior.
 * One failed data set leaves the others running, and the run exits
   nonzero at the end.
-* The smallest amount of custom concurrency code that stays correct, so
-  the sequential and parallel paths stay testable.
+* Least custom concurrency code that stays correct and testable.
 * A ready task starts as soon as its own dependencies finish, not at a
   batch boundary.
 
@@ -80,9 +72,6 @@ valid topological order that reproduces the sequential path.
   sort key, so a reader sees why each task waits.
 * Good: independent data sets run as soon as they're ready, up to the
   job limit, with no batch barrier.
-* Good: all graph bookkeeping stays on the main thread, so no lock
-  guards the shared state, and the loop ends when the last future
-  drains, without poison pills.
 * Bad: the edge builder and dispatcher add code and test surface that
   the sequential loop never needed.
 * Neutral: the depth sort that ordered tasks before goes away, replaced
@@ -105,8 +94,8 @@ dependencies have finished, runs it when they have, and pushes it back
 when they haven't.
 
 * Good: one queue, little structure.
-* Bad: a not-ready task cycles through the queue again and again, which
-  burns cycles and needs a delay to avoid a busy spin.
+* Bad: a not-ready task cycles back repeatedly until a delay throttles
+  the spin.
 * Bad: workers share the completion state, so a lock guards it.
 * Bad: ordering emerges from the churn rather than from a stated rule,
   which is hard to reason about.
@@ -129,9 +118,7 @@ reaches the same behavior without the extra thread or the queues.
 
 ### C -- Main-thread dispatcher over a bounded `ThreadPoolExecutor`
 
-The chosen option. The executor's internal queue serves as the ready
-holding area, and `futures.wait(FIRST_COMPLETED)` serves as the waiter,
-so the dispatcher stays a single main-thread loop.
+The chosen option.
 
 * Good: no coordinator thread, no hand-built queue, no poison pills.
 * Good: graph mutation stays on the main thread, so no lock.
@@ -151,8 +138,8 @@ waiting for the whole level before the next starts.
 
 ## More Information
 
-Issue [#394](https://github.com/alunduil/zfs-replicate/issues/394)
-carries the acceptance criteria and the `--jobs` flag. The dependency on
-operational output flowing through the logging module (issue
+Issue [#394](https://github.com/alunduil/zfs-replicate/issues/394) has
+the acceptance criteria. The dependency on operational output flowing
+through the logging module (issue
 [#434](https://github.com/alunduil/zfs-replicate/issues/434)) landed
 first, so log records stay one line under concurrency.

--- a/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
+++ b/docs/adr/0001-schedule-parallel-replication-with-a-dependency-graph.md
@@ -6,14 +6,19 @@ Accepted
 
 ## Context and Problem Statement
 
-`task/execute.py` replicates filesystems one at a time. For an operator
-with many independent data sets, a run takes the sum of the times for
-every data set rather than the time of the slowest one (issue
-[#394](https://github.com/alunduil/zfs-replicate/issues/394), and the
-original request in
-[#3](https://github.com/alunduil/zfs-replicate/issues/3)). The data sets
-are independent: their send
-and receive pipes share no ordering constraint.
+`task/execute.py` replicates filesystems one at a time, so a run's total
+time is the sum of the times for every data set. The data sets are
+independent: their send and receive pipes share no ordering constraint,
+and running them concurrently trims that time. The gain stays bounded
+rather than unlimited: `--jobs N` caps concurrency at N workers,
+and a single data set stays serial, since its create precedes its sends
+and its incremental sends run in order. By Amdahl's law the speedup
+tracks the parallel fraction and the worker count. The floor is the
+longest single data set plus the serial work every run shares -- listing
+snapshots, creating the destination root, and planning the tasks. Issue
+[#394](https://github.com/alunduil/zfs-replicate/issues/394) targets
+this, drawing on the original request in
+[#3](https://github.com/alunduil/zfs-replicate/issues/3).
 
 The tasks reaching `execute()` still carry ordering constraints, but the
 current code encodes them by accident. `generate.py` emits a `CREATE`

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -1,3 +1,4 @@
+Amdahl
 argparse
 docstring
 MADR

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -1,5 +1,7 @@
 argparse
 docstring
+MADR
+Nygard
 release-please
 semver
 subprocess


### PR DESCRIPTION
## Summary

Introduces Architecture Decision Records to the repo and records the design behind #394's parallel replication. `execute()` iterates filesystems sequentially today; the plan is to run independent data sets concurrently under a `-j/--jobs` limit. Rather than wrap the existing loop in a pool — which would race, since a data set's `CREATE` and its `SEND`s reach `execute()` as separate groups ordered only by an incidental depth sort — the decision is to make the ordering an explicit task dependency graph and schedule it with a main-thread dispatcher over a bounded `ThreadPoolExecutor`.

`0000` establishes the ADR practice (short Nygard form). `0001` captures the scheduler decision in MADR form, weighing four options and recording why the graph-plus-dispatcher wins over a self-scheduling queue, a coordinator thread, or level barriers.

This documents the decision only; the implementation lands separately.

Refs #394. Depends-on the logging chore (#434), already merged.

## Gotchas

- ADRs here land as `Accepted`: merging into the default branch is the acceptance, since review happens on the pull request. `0000` states that lifecycle policy — no transient `Proposed` status. Disagree with the design? This PR is the place, before merge.
- Prose uses **data set** (two words) throughout because Vale enforces that term as an error here, matching the CHANGELOG. `Nygard` and `MADR` were added to the Vale vocabulary (`styles/config/vocabularies/ZFS/accept.txt`) so the proper nouns pass.
- The four ordering rules and the dispatcher shape in `0001` are the load-bearing part to review — they're what the eventual implementation will be built and tested against.

## Test plan

- `vale docs/adr/` — 0 errors (remaining warnings/suggestions match the categories the committed docs already carry).
- Full `pre-commit` ran clean on both commits.