### PR TITLE
build!: require Python 3.11 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"  # EOL 2025-10
-          - "3.10"  # EOL 2026-10
           - "3.11"  # EOL 2027-10
           - "3.12"  # EOL 2028-10
+          - "3.13"  # EOL 2029-10
+          - "3.14"  # EOL 2030-10
         experimental: [false]
         include:
           - python-version: 3.x
@@ -57,10 +57,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"  # EOL 2025-10
-          - "3.10"  # EOL 2026-10
           - "3.11"  # EOL 2027-10
           - "3.12"  # EOL 2028-10
+          - "3.13"  # EOL 2029-10
+          - "3.14"  # EOL 2030-10
         experimental: [false]
         include:
           - python-version: 3.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Renamed `--raw / --no-raw` (4.1.0) to `--send-raw / --send-no-raw` so every send flag shares the `--send-` prefix; the default still sends `zfs send -w` for encrypted data sets (#392).
 - `--follow-delete` no longer implies `zfs send -p`. Send properties are now controlled solely by `--send-props`; pass it alongside `--follow-delete` to keep the earlier behaviour (#392).
 
+### Removed
+
+- Support for Python 3.9 and 3.10. The minimum supported version is now Python 3.11. Python 3.9 reached upstream end-of-life on 2025-10-31 and 3.10 reaches it on 2026-10-31; the supported set now tracks the CPython releases upstream still supports, and the test matrix covers 3.11 through 3.14 (#398, #461).
+
 ## 4.1.0 -- 2026-05-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,25 @@ Small change examples:
 * Typographical error corrections, space, and formatting changes
 * Comment clean ups
 
+## Supported Python versions
+
+zfs-replicate supports the CPython releases that upstream still supports. A
+release counts as supported until its end-of-life date in the
+[Python release cycle]. After that date passes, the release leaves the
+supported set.
+
+Three places have to agree on that set:
+
+1. `requires-python` in `pyproject.toml` names the floor.
+1. `python` under `[tool.poetry.dependencies]` names the same floor.
+1. Each `python-version` list in `.github/workflows/ci.yml` names every
+   supported release, annotated with its end-of-life month.
+
+Adding a newly released version is a `ci` change. Raising the floor drops
+support for users still on the old version, so a floor raise is a breaking
+change: mark it with `!` and a `BREAKING CHANGE:` footer, and record it under
+`Removed` in the changelog.
+
 ## How to report a bug
 
 When creating an issue for a bug or unexpected behaviour, make sure you include
@@ -184,3 +203,4 @@ release on their own.
 [good first issues]: https://github.com/alunduil/zfs-replicate/issues?q=is%3Aissue+label%3A%22good+first+issue%22+is%3Aopen
 [How to Contribute to an Open Source Project on GitHub]: https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github
 [Make a Pull Request]: https://makeapullrequest.com/
+[Python release cycle]: https://devguide.python.org/versions/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ under the terms of the `BSD-2-Clause` licence. See the [LICENSE] for details.
 
 ## Prerequisites
 
+1. Python 3.11 or later on the local system
 1. A remote system with a ZFS filesystem and the `zfs` command-line tools
 1. If using lz4 compression, local and remote systems must have lz4 in their environments
 1. SSH access to that remote system

--- a/poetry.lock
+++ b/poetry.lock
@@ -235,9 +235,6 @@ files = [
     {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
@@ -273,22 +270,6 @@ files = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-groups = ["test"]
-markers = "python_version < \"3.11\""
-files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
-
-[[package]]
 name = "hypothesis"
 version = "6.141.1"
 description = "A library for property-based testing"
@@ -302,7 +283,6 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
-exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
@@ -392,11 +372,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=1.5,<2"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -455,19 +433,6 @@ files = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-groups = ["test"]
-markers = "python_full_version <= \"3.11.0a6\""
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -487,5 +452,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "da9aae659a71105abe50f2d149924f097352ddbb0c4a86de7e174dc6af9641c8"
+python-versions = "^3.11"
+content-hash = "b883ae15e02428c55d99d963e0d438cdb64ff113b450a62159de67e34791303e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["zfs", "replication", "backup", "remote"]
 license = "BSD-2-Clause"
 name = "zfs-replicate"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.11,<4.0"
 version = "4.1.0"
 
 [project.scripts]
@@ -46,7 +46,7 @@ requires-poetry = ">=2.0"
 [tool.poetry.dependencies]
 click = "^8.1.3"
 click-log = "^0.4.0"
-python = "^3.9"
+python = "^3.11"
 
 [tool.poetry.group.test.dependencies]
 coveralls = ">=2.1.1,<4.0.0"

--- a/styles/config/vocabularies/ZFS/accept.txt
+++ b/styles/config/vocabularies/ZFS/accept.txt
@@ -1,5 +1,6 @@
 Amdahl
 argparse
+CPython
 docstring
 MADR
 Nygard

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -51,7 +51,9 @@ def _snapshots(zfs_list_output: bytes) -> List[Snapshot]:
 
     snapshots[0] = _add_previous(snapshots[0], None)
 
-    return [snapshots[0]] + [_add_previous(s, p) for s, p in zip(snapshots[1:], snapshots)]
+    # strict=False: the operands are deliberately unequal in length, pairing each
+    # snapshot after the first with its predecessor.
+    return [snapshots[0]] + [_add_previous(s, p) for s, p in zip(snapshots[1:], snapshots, strict=False)]
 
 
 def _snapshot(zfs_list_line: bytes) -> Snapshot:


### PR DESCRIPTION
## Summary

The support matrix had drifted from upstream reality in both directions: CI ran
Python 3.9, which reached end-of-life on 2025-10-31, while never exercising 3.13
or 3.14 even though `requires-python = ">=3.9"` advertised them. This raises the
floor to 3.11 and tests 3.11 through 3.14, so what we claim to support and what
we actually test are the same set.

`CONTRIBUTING.md` gains a written rule defining the supported set as the upstream
non-EOL CPython releases, naming the three files that have to agree on it. That
is the part meant to stop this from drifting again.

Closes #398
Closes #461

## Gotchas

- **The floor is 3.11, not the 3.10 that #398 proposed.** A strict reading of the
  new convention would say 3.10, since it is non-EOL today, but it goes EOL
  2026-10-31, so we would add a CI leg now and delete it in three months. 3.11
  runs to 2027-10-31 and is where `StrEnum` and `typing.Self` landed, both named
  in #398's user story. Worth a second opinion if you would rather hold at 3.10.
- **#398's typing-migration criterion is not in this PR.** #501 owns enabling
  ruff's `UP` rules and explicitly wants that ~99-annotation churn isolated from
  rule-config changes. Raising the floor here is what unblocks its PEP 604
  rewrites, so #501 should land next.
- **One source file changed in an otherwise metadata-only PR.** The higher floor
  lets ruff infer a newer target version, which turns on `B905`. The `zip()` in
  `zfs/replicate/snapshot/list.py:54` pairs operands of deliberately unequal
  length, so it takes `strict=False` rather than `True`.
- **#398 asked for a classifier update with no resulting diff.** Poetry generates
  the version classifiers from the constraint, so they moved to 3.11 through 3.14
  on their own. Verified against the built artifact rather than assumed.
- **#398 also asked for a README prerequisites update.** That section never
  mentioned Python at all, so this adds the floor rather than editing a version.

## Test plan

- `pre-commit run --all-files`: all hooks pass, including mypy, ruff, and vale.
- `pytest`: 50 passed, 85% coverage.
- `poetry check`: passes after `poetry lock`.
- `poetry build`, then read `PKG-INFO` out of the sdist to confirm the generated
  metadata: `Requires-Python: >=3.11,<4.0` with classifiers for 3.11, 3.12, 3.13,
  and 3.14, matching the CI matrix exactly.
- EOL dates cross-checked against both <https://devguide.python.org/versions/>
  and the endoflife.date API rather than recalled.
