### PR TITLE
ci: harden renovate config and track vale pin

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,8 +10,9 @@ poetry install
 # 2) Install the pre-commit hook into the local clone.
 pre-commit install
 
-# 3) Vale linter. Pinned to a recent stable; bump when CI starts using
-#    a newer rule pack.
+# 3) Vale linter. The release tarball names carry a bare version while the
+#    upstream tags are v-prefixed, hence extractVersion.
+# renovate: datasource=github-releases depName=errata-ai/vale extractVersion=^v(?<version>.+)$
 VALE_VERSION="3.10.1"
 VALE_ARCH="64-bit"
 VALE_TARBALL="vale_${VALE_VERSION}_Linux_${VALE_ARCH}.tar.gz"

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,39 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "schedule:weekly"],
-  "baseBranchPatterns": ["master"],
+  "extends": [
+    "config:best-practices",
+    "security:openssf-scorecard",
+    "customManagers:githubActionsVersions"
+  ],
+  "timezone": "Europe/London",
   "reviewers": ["alunduil"],
   "pre-commit": {"enabled": true},
   "minimumReleaseAge": "3 days",
-  "internalChecksFilter": "strict",
-  "vulnerabilityAlerts": {"minimumReleaseAge": "0 days"},
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "description": "Exempt update types that carry no release timestamp from the minimum release-age bake, so their renovate/stability-days check can resolve under internalChecksFilter:strict",
-      "matchUpdateTypes": ["pin", "pinDigest", "digest", "lockFileMaintenance"],
-      "minimumReleaseAge": "0 days"
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "lockfileUpdate",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
+      "minimumReleaseAge": null
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Read `# renovate:` annotations above *_VERSION pins in dev container setup scripts",
+      "managerFilePatterns": [".devcontainer/*"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: packageName=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION=\"(?<currentValue>.+?)\""
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Dependency updates that carry no release timestamp can no longer stall
invisibly, and the Vale pin in the dev container is now something Renovate can
see. The stall is the one worth caring about: with `minimumReleaseAge` set and
strict internal checks, an update type that cannot carry a timestamp waits on a
stability check that never resolves, and because no branch is ever cut there is
no PR to notice. The previous carve-out covered four such update types out of
eight.

The rest is drift cleanup against the current Renovate defaults, plus dropping
`schedule:weekly` now that the three-day bake period and the default hourly PR
limit already pace things.

## Gotchas

- The three deleted fields (`internalChecksFilter`,
  `vulnerabilityAlerts.minimumReleaseAge`, `baseBranchPatterns`) read as a
  behaviour change but are all current Renovate defaults, so removing them
  changes nothing. `baseBranchPatterns` is auto-detected, and dropping it is
  what makes the top of this file identical across repos, so it can move to a
  shared preset later.
- `security:openssf-scorecard` is not #414. The preset adds a scorecard column
  to Renovate's own PR bodies; #414 wants `ossf/scorecard-action` grading this
  repo and uploading SARIF. Adding one does not advance the other.
- `VALE_VERSION` stays at 3.10.1 on purpose even though it has drifted five
  minor versions behind the pre-commit hook. Renovate's first PR against that
  pin is the end-to-end proof the new custom manager matches, which a hand bump
  in this PR would hide.
- `replacement` is the likeliest of the four newly covered update types to
  matter here, since the dependency dashboard already flags `click-log`,
  `pre-commit/action`, and `FawltyDeps` as abandoned.

## Test plan

- Tested the custom manager's `matchStrings` against the real
  `.devcontainer/post-create.sh` before committing, because a non-matching
  manager is indistinguishable from a dependency with no updates. It captures
  one match with `datasource=github-releases`, `depName=errata-ai/vale`,
  `extractVersion=^v(?<version>.+)$`, `currentValue=3.10.1`. Checked with
  Python's `re`, which is faithful here because the pattern uses no lookahead or
  backreferences and stays inside the subset RE2 and Python agree on.
- `pre-commit run --all-files` passes, including `renovate-config-validator`
  with `--strict --no-global`, which also confirms no field in the file needs
  migration.
- Read the dependency dashboard (#510) to ground the findings rather than infer
  them. It reports no Repository Problems and no Config Migration Needed, and it
  confirms `VALE_VERSION` was absent from Detected Dependencies.

Two devcontainer observations came out of the review and are deliberately not
addressed here: the five features still float on mutable major tags with no
digests, and the base image does not appear in Detected Dependencies at all.
Both want a look at the next dashboard refresh.
