### PR TITLE
build: type-check the mypy hook against the project's real dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,15 @@ repos:
     rev: v1.18.2
     hooks:
       - id: mypy
+        # click and hypothesis ship py.typed. Without them in the hook's
+        # environment --ignore-missing-imports degrades every decorator they
+        # export to Any, which strict mode then reports as an untyped
+        # decorator at each of the ~25 call sites.
         additional_dependencies:
-          - types-requests
-          - types-retry
-          - types-toml
+          - click
+          - click-log
+          - hypothesis
+          - pytest
   - repo: https://github.com/jendrikseipp/vulture
     rev: v2.16
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Renamed `--raw / --no-raw` (4.1.0) to `--send-raw / --send-no-raw` so every send flag shares the `--send-` prefix; the default still sends `zfs send -w` for encrypted data sets (#392).
 - `--follow-delete` no longer implies `zfs send -p`. Send properties are now controlled solely by `--send-props`; pass it alongside `--follow-delete` to keep the earlier behaviour (#392).
+- Raised the minimum Click to 8.2, which made `click.Choice` generic. `EnumChoice` now subscripts it, so 8.1 fails at import. Click 8.2 requires Python 3.10, which the current floor already sets (#456).
 
 ### Removed
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -735,4 +735,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "8daf0748a4f3cb156fdcf66f409cbcdd0cc9abadc5db8a0ec870e619c1ab997a"
+content-hash = "2525380a044bb4d3f7d5983f9163b36b1b9246134b637f5e5a4499f236035600"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ packages = [{include = "zfs"}, {include = "zfs_test", format = "sdist"}]
 requires-poetry = ">=2.0"
 
 [tool.poetry.dependencies]
-click = "^8.1.3"
+click = "^8.2"
 click-log = "^0.4.0"
 python = "^3.10"
 

--- a/zfs/replicate/cli/click.py
+++ b/zfs/replicate/cli/click.py
@@ -6,7 +6,7 @@ from typing import Any
 import click
 
 
-class EnumChoice(click.Choice):  # type: ignore[misc]
+class EnumChoice(click.Choice[str]):
     """Choice made from Enum."""
 
     # Need any due to the private member only existing on subclasses through

--- a/zfs/replicate/cli/log.py
+++ b/zfs/replicate/cli/log.py
@@ -11,8 +11,11 @@ module owns how that output is presented, which is the command line's concern.
 
 import logging
 import sys
+from typing import Any, Callable, TypeVar
 
 import click_log
+
+_F = TypeVar("_F", bound=Callable[..., Any])
 
 logger = logging.getLogger("zfs.replicate")
 
@@ -50,8 +53,10 @@ class _Formatter(click_log.ColorFormatter):  # type: ignore[misc]
 
 # The --verbosity/-v option, wired to the zfs.replicate logger. Default WARNING
 # keeps a plain run quiet; click-log's own default is INFO. Read qualified as
-# ``log.option``.
-option = click_log.simple_verbosity_option(logger, default="WARNING")
+# ``log.option``. The annotation is load-bearing: click-log is untyped, so the
+# call returns Any and strict mode would report every use as an untyped
+# decorator.
+option: Callable[[_F], _F] = click_log.simple_verbosity_option(logger, default="WARNING")
 
 
 def configure() -> None:

--- a/zfs/replicate/cli/main.py
+++ b/zfs/replicate/cli/main.py
@@ -15,20 +15,20 @@ from .click import EnumChoice
 log.configure()
 
 
-@click.command()  # type: ignore[misc]
-@log.option  # type: ignore[misc]
-@click.option(  # type: ignore[misc]
+@click.command()
+@log.option
+@click.option(
     "--dry-run",
     is_flag=True,
     help="Generate replication tasks but do not execute them.",
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--follow-delete",
     is_flag=True,
     help="Delete snapshots on REMOTE_FS that have been deleted from LOCAL_FS.",
 )
-@click.option("--recursive", is_flag=True, help="Recursively replicate snapshots.")  # type: ignore[misc]
-@click.option(  # type: ignore[misc]
+@click.option("--recursive", is_flag=True, help="Recursively replicate snapshots.")
+@click.option(
     "--port",
     "-p",
     type=click.IntRange(1, 65535),
@@ -36,7 +36,7 @@ log.configure()
     default=22,
     help="Connect to SSH on PORT.",
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--login",
     "-l",
     "--user",
@@ -45,20 +45,20 @@ log.configure()
     metavar="USER",
     help="Connect to SSH as USER.",
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "-i",
     "--identity-file",
     type=click.Path(exists=True, dir_okay=False),
     required=True,
     help="SSH identity file to use.",
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--cipher",
     type=EnumChoice(Cipher),
     default=Cipher.STANDARD,
     help="One of: disable (no ciphers), fast (only fast ciphers), or standard (default ciphers).",
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--compression",
     type=EnumChoice(Compression),
     default=Compression.LZ4,
@@ -66,9 +66,9 @@ log.configure()
 )
 @options.send_group
 @options.receive_group
-@click.argument("host", required=True)  # type: ignore[misc]
-@click.argument("remote_fs", type=filesystem_t, required=True, metavar="REMOTE_FS")  # type: ignore[misc]
-@click.argument("local_fs", type=filesystem_t, required=True, metavar="LOCAL_FS")  # type: ignore[misc]
+@click.argument("host", required=True)
+@click.argument("remote_fs", type=filesystem_t, required=True, metavar="REMOTE_FS")
+@click.argument("local_fs", type=filesystem_t, required=True, metavar="LOCAL_FS")
 def main(  # noqa: PLR0913 -- CLI entry point; each argument is a distinct command-line option
     dry_run: bool,
     follow_delete: bool,

--- a/zfs/replicate/error.py
+++ b/zfs/replicate/error.py
@@ -5,7 +5,7 @@ from typing import Any
 from click import ClickException
 
 
-class ZFSReplicateError(ClickException):  # type: ignore[misc]
+class ZFSReplicateError(ClickException):
     """Base ZFS Replication Error."""
 
     def __init__(self, message: str, *_args: Any) -> None:

--- a/zfs_test/replicate_test/list_test.py
+++ b/zfs_test/replicate_test/list_test.py
@@ -8,20 +8,20 @@ from hypothesis.strategies import integers, lists, sets
 from zfs.replicate import list as sut
 
 
-@given(lists(integers()))  # type: ignore[misc]
+@given(lists(integers()))
 def test_inits_length(elements: List[int]) -> None:
     """len(inits(elements)) == len(elements) + 1."""
     assert len(sut.inits(elements)) == len(elements) + 1
 
 
-@given(lists(integers(), min_size=2))  # type: ignore[misc]
+@given(lists(integers(), min_size=2))
 def test_inits_heads(elements: List[int]) -> None:
     """inits(elements)[:1] == [[], [elements[0]]."""
     assert sut.inits(elements)[0] == []
     assert sut.inits(elements)[1] == [elements[0]]
 
 
-@given(lists(integers()))  # type: ignore[misc]
+@given(lists(integers()))
 def test_inits_monotonic_length(elements: List[int]) -> None:
     """[len(x) for xs in inits(elements)] == range(len(elements) + 1)."""
     lengths = [len(xs) for xs in sut.inits(elements)]
@@ -29,7 +29,7 @@ def test_inits_monotonic_length(elements: List[int]) -> None:
     assert lengths == list(range(len(elements) + 1))
 
 
-@given(sets(integers()), sets(integers()))  # type: ignore[misc]
+@given(sets(integers()), sets(integers()))
 def test_venn_subsets(lefts: Set[int], rights: Set[int]) -> None:
     """All combinations of venn with subsets."""
     r_lefts: List[int]
@@ -53,7 +53,7 @@ def test_venn_subsets(lefts: Set[int], rights: Set[int]) -> None:
     )
 
 
-@given(lists(integers()))  # type: ignore[misc]
+@given(lists(integers()))
 def test_venn_disjoint(both: List[int]) -> None:
     """Venn with disjoint."""
     e_lefts = list(filter(lambda x: x % 2 == 0, both))

--- a/zfs_test/replicate_test/optional_test.py
+++ b/zfs_test/replicate_test/optional_test.py
@@ -17,7 +17,7 @@ def test_value_none() -> None:
         raise AssertionError("Expected RuntimeError") from None
 
 
-@given(integers())  # type: ignore[misc]
+@given(integers())
 def test_value_not_none(value: int) -> None:
     """optional.value(value) == value."""
     assert optional.value(value) == value

--- a/zfs_test/replicate_test/snapshot_test/list_test.py
+++ b/zfs_test/replicate_test/snapshot_test/list_test.py
@@ -10,21 +10,21 @@ from zfs.replicate.snapshot.type import Snapshot
 from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
-@given(lists(SNAPSHOTS))  # type: ignore[misc]
+@given(lists(SNAPSHOTS))
 def test_snapshots(snapshots: List[Snapshot]) -> None:
     """_snapshots."""
     output = "\n".join([_output(s) for s in snapshots])
     assert _snapshots(output.encode()) == snapshots
 
 
-@given(lists(SNAPSHOTS, min_size=1))  # type: ignore[misc]
+@given(lists(SNAPSHOTS, min_size=1))
 def test_snapshots_depth(snapshots: List[Snapshot]) -> None:
     """Ensure max depth of 2."""
     output = "\n".join([_output(s) for s in snapshots])
     assert max(map(_depth, _snapshots(output.encode()))) <= 2
 
 
-@given(SNAPSHOTS)  # type: ignore[misc]
+@given(SNAPSHOTS)
 def test_snapshot(snapshot: Snapshot) -> None:
     """_snapshot."""
     assert _snapshot(_output(snapshot).encode()) == snapshot

--- a/zfs_test/replicate_test/task_test/generate_test.py
+++ b/zfs_test/replicate_test/task_test/generate_test.py
@@ -19,7 +19,7 @@ def test_no_tasks() -> None:
     assert not generate(filesystem("pool/filesystem"), {}, {})
 
 
-@given(lists(SNAPSHOTS))  # type: ignore[misc]
+@given(lists(SNAPSHOTS))
 def test_empty_remotes(snapshots: List[Snapshot]) -> None:
     """Generate with empty remotes."""
     snapshots_by_fs = {
@@ -38,7 +38,7 @@ def test_empty_remotes(snapshots: List[Snapshot]) -> None:
     )
 
 
-@given(lists(SNAPSHOTS))  # type: ignore[misc]
+@given(lists(SNAPSHOTS))
 def test_empty_locals(snapshots: List[Snapshot]) -> None:
     """Generate with empty locals."""
     snapshots_by_fs = {

--- a/zfs_test/replicate_test/task_test/report_test.py
+++ b/zfs_test/replicate_test/task_test/report_test.py
@@ -14,7 +14,7 @@ def test_empty_tasks() -> None:
     assert report([]) == ""
 
 
-@given(tasks=lists(builds(Task), min_size=1))  # type: ignore[misc]
+@given(tasks=lists(builds(Task), min_size=1))
 def test_nonempty_tasks(tasks: List[Task]) -> None:
     """Ensure nonempty report from nonempty actions."""
     result = report(tasks)


### PR DESCRIPTION
## Summary

The `mirrors-mypy` hook ran against a tree it could not see. Its virtualenv held only `types-requests`, `types-retry`, and `types-toml`, none of which anything under `zfs/` or `zfs_test/` imports, while the packages that are imported were absent. `mirrors-mypy` passes `--ignore-missing-imports`, so `click`, `click_log`, `hypothesis`, and `pytest` all resolved to `Any`, every decorator they export read as untyped, and 25 `# type: ignore[misc]` markers existed to silence that. The markers were load-bearing only against the blind spot.

Giving the hook the dependencies it checks makes those 25 markers unused, so they come out, and mypy now checks the CLI surface against Click's real signatures. Two sites needed a typed path instead of a deletion: `EnumChoice` subscripts `click.Choice`, and `log.option` carries an explicit `Callable` annotation because `click-log` ships no type information.

This also unblocks the stuck Renovate hook bumps. mypy 2.0 split `untyped-decorator` out of `misc`, which left every `[misc]` marker simultaneously unused and insufficient, failing the hook 50 times.

Closes #514. Closes #456.

## Gotchas

`click.Choice` only became generic in 8.2, so `class EnumChoice(click.Choice[str])` raises `TypeError: type 'Choice' is not subscriptable` at import under 8.1, which the old `^8.1.3` floor still admitted. The lockfile resolves 8.4.2, so no test would have caught this; I found it by installing 8.1.8 deliberately. Hence the floor moves to `^8.2`, which costs no supported interpreter since Click 8.2 requires Python 3.10 and cc7fb07 already set that floor.

This lands ahead of #513, which the `blocked` label on #514 was sequencing it behind. That edge inverts here: after this, a new `@click.option` needs no suppression at all, so #513's rebase deletes its two new `# type: ignore[misc]` comments rather than keeping them. The overlap in `cli/main.py` is textual and small.

## Test plan

- `pre-commit run --all-files` passes, including the `mypy` hook.
- Temporarily set the hook's `rev` to `v2.3.0` and re-ran it: passes. That is the bump in #530, so this makes it green without touching that branch.
- Ran mypy directly at both 1.18.2 and 2.3.0 over `git ls-files '*.py'`: `Success: no issues found in 60 source files` each time.
- `pytest`: 50 passed.
- `zfs-replicate --help` renders the full option list, including the `EnumChoice`-backed `--cipher` and `--compression` and the `click-log` `--verbosity`.
- Confirmed the failure mode the floor bump prevents: importing `zfs.replicate.cli.main` under `click==8.1.8` raises `TypeError`, and under the locked 8.4.2 it does not.
