### PR TITLE
chore(deps): upgrade FawltyDeps hook to v0.20.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,11 +54,10 @@ repos:
         args: [--autofix]
         exclude: poetry\.lock
   - repo: https://github.com/tweag/FawltyDeps
-    rev: v0.13.1
+    rev: v0.20.0
     hooks:
-      - id: check
-        args:
-          - --detailed
+      - id: check-undeclared
+      - id: check-unused
   - repo: https://github.com/errata-ai/vale
     rev: v3.15.1
     hooks:


### PR DESCRIPTION
## Summary

The `pre-commit` hook for FawltyDeps moves to v0.20.0 and adopts the two
hook ids that version actually ships. Renovate's #524 bumped `rev:` alone
and failed at environment setup with ``` `check` is not present in
repository https://github.com/tweag/FawltyDeps ```, because v0.13.3 split
the single `check` hook into `check-undeclared` and `check-unused`
(tweag/FawltyDeps#386). Renovate rewrites `rev:` but never hook ids, so
that PR could not have gone green without this hand edit.

Refs #524

## Gotchas

- The dropped `args: [--detailed]` is the one line worth a second look.
  `pre-commit` replaces a hook's default args rather than appending to
  them, so carrying that block onto the new hooks would have silently
  stripped their `--code` and `--deps` defaults and narrowed each hook to
  the wrong half of the project. Both new hooks already carry
  `--detailed` in their `entry`, so nothing is lost by removing it.
- Please let #524 close itself rather than closing it by hand. Renovate
  reads a manually closed PR as "never offer this update again" and would
  stop proposing FawltyDeps bumps entirely. Once master carries v0.20.0
  it retires that PR on its own.

## Test plan

- Ran `pre-commit run --all-files` on the upgraded config: all 23 hooks
  pass, including `FawltyDeps-undeclared` and `FawltyDeps-unused`.
- Seven minor versions of detection changes surface no new undeclared or
  unused dependencies here. The existing `ignore_unused` in
  `pyproject.toml` still covers `coveralls`, `pytest-cov`, and `vale`.