### PR TITLE
refactor: make wide call surfaces keyword-only

### DIFF
--- a/zfs/replicate/cli/main.py
+++ b/zfs/replicate/cli/main.py
@@ -70,6 +70,7 @@ log.configure()
 @click.argument("remote_fs", type=filesystem_t, required=True, metavar="REMOTE_FS")
 @click.argument("local_fs", type=filesystem_t, required=True, metavar="LOCAL_FS")
 def main(  # noqa: PLR0913 -- CLI entry point; each argument is a distinct command-line option
+    *,
     dry_run: bool,
     follow_delete: bool,
     recursive: bool,

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -17,6 +17,7 @@ from .type import Snapshot
 def send(  # noqa: PLR0913 -- carries the full replication call surface
     remote: FileSystem,
     current: Snapshot,
+    *,
     ssh_command: Command,
     compression: Compression,
     send_options: SendOptions,

--- a/zfs/replicate/task/execute.py
+++ b/zfs/replicate/task/execute.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 def execute(  # noqa: PLR0913 -- carries the full replication call surface
     remote: FileSystem,
     tasks: List[Tuple[FileSystem, List[Task]]],
+    *,
     ssh_command: Command,
     compression: Compression,
     send_options: send.Options,
@@ -69,6 +70,7 @@ def _destroy(tasks: List[Task], ssh_command: Command) -> None:
 def _send(  # noqa: PLR0913 -- carries the full replication call surface
     remote: FileSystem,
     tasks: List[Task],
+    *,
     ssh_command: Command,
     compression: Compression,
     send_options: send.Options,


### PR DESCRIPTION
## Summary

The `astral-sh/ruff-pre-commit` bump to v0.16.0 in #540 fails `ruff check`,
because 0.16.0 promotes `PLR0917` (too many positional arguments) to stable.
That is a separate code from the `PLR0913` already suppressed on `cli.main`,
`snapshot.send`, `task.execute`, and `task._send`, so those four pre-existing
signatures start erroring under the new hook. A bare `*` in each signature
clears `PLR0917` outright and unblocks the bump.

Refs #540

## Gotchas

- Extending each `noqa` to `PLR0913,PLR0917` is the smaller diff, but it
  cannot land before the bump does: under the pinned 0.15.22, `PLR0917` is
  preview-only and `RUF100` rejects the directive as non-enabled. That is why
  this takes the signature route instead.
- The four functions are now keyword-only past their first argument or two,
  which narrows a public import surface. Nothing in the tree passes those
  arguments positionally today, and `click` dispatches `main` with `**params`,
  so the change is inert here. It is worth a second look if you consider
  `zfs.replicate` an importable API rather than CLI internals, since the
  commit type is `refactor:` and release-please will not cut a release for it.
- `PLR0913` still fires on the total parameter count, so the existing
  suppressions and their justifications stay in place.

## Test plan

- Ran `ruff check` under both 0.15.22 and 0.16.0, clean on each. The fix has
  to be version-agnostic to land ahead of #540.
- Ran `pre-commit run --all-files`, all hooks pass.
- Ran `pytest`, 50 passed.
- Ran `zfs-replicate --help` and confirmed `click` still dispatches through
  the keyword-only `main`.