### PR TITLE
ci: prune stale pull requests on a daily schedule

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,11 +1,11 @@
 name: Daily
 
 on:
-  # GitHub cron takes no timezone and always runs UTC, so this lands at 07:47
-  # through BST and 06:47 through GMT. The offset from the hour is deliberate:
-  # schedules on the hour queue behind the platform's peak load.
+  # Offset from the hour deliberately: schedules landing on the hour queue
+  # behind the platform's peak load.
   schedule:
     - cron: '47 6 * * *'
+      timezone: 'Europe/London'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,8 +1,11 @@
-name: Scheduled
+name: Daily
 
 on:
+  # GitHub cron takes no timezone and always runs UTC, so this lands at 07:47
+  # through BST and 06:47 through GMT. The offset from the hour is deliberate:
+  # schedules on the hour queue behind the platform's peak load.
   schedule:
-    - cron: '18 10 * * *'
+    - cron: '47 6 * * *'
   workflow_dispatch:
 
 permissions:
@@ -26,7 +29,7 @@ jobs:
       # Issues are out of scope on both legs (#453). The previous bot re-closed
       # #359 after it had been deliberately reopened, and four open issues still
       # carry `no-issue-activity` from it. Excluding them from staling alone
-      # would leave those four eligible for closing on the first armed run.
+      # would leave those four eligible for closing on the next run.
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
         with:
           days-before-issue-stale: -1
@@ -36,16 +39,15 @@ jobs:
           stale-pr-label: no-pr-activity
           # Closing a Renovate pull request tells Renovate the update is
           # unwanted and it will not offer that version again, so `dependencies`
-          # is a correctness exemption rather than a courtesy one.
+          # is a correctness exemption rather than a courtesy one. `no stale` is
+          # the manual opt-out and stays inert until that label is declared in
+          # alunduil/alunduil-infrastructure#330.
           exempt-pr-labels: blocked,dependencies,no stale
           stale-pr-message: >-
-            No activity here for 30 days, so this is now marked stale. A comment
-            or a push clears the label and restarts the clock. Without one, this
-            closes in 14 days.
+            This has been quiet for 30 days, so it's picked up a stale label. A
+            comment or a push clears the label and restarts the clock. Otherwise
+            this closes in another 14 days.
           close-pr-message: >-
-            Closed after 44 days without activity. That is queue cleaning rather
-            than a verdict on the change: the branch is untouched, and a comment
-            here is enough to get this reopened.
-          # Reporting only until the `no stale` label exists, since it is the
-          # sole opt-out for work in progress that should outlive the timer.
-          debug-only: true
+            Closing this after 44 quiet days. That isn't a call on the change
+            itself, and nothing is lost: the branch stays where it is, so
+            comment here if you want to pick it back up and I'll reopen it.

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,51 @@
+name: Scheduled
+
+on:
+  schedule:
+    - cron: '18 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  stale-pull-requests:
+    name: Prune stale pull requests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      # The action's README also asks for `actions: write`, which covers only
+      # its operations-per-run resume cache. Without that scope a truncated run
+      # warns and restarts from the first pull request instead of failing.
+      issues: write
+      pull-requests: write
+    steps:
+      # Issues are out of scope on both legs (#453). The previous bot re-closed
+      # #359 after it had been deliberately reopened, and four open issues still
+      # carry `no-issue-activity` from it. Excluding them from staling alone
+      # would leave those four eligible for closing on the first armed run.
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: no-pr-activity
+          # Closing a Renovate pull request tells Renovate the update is
+          # unwanted and it will not offer that version again, so `dependencies`
+          # is a correctness exemption rather than a courtesy one.
+          exempt-pr-labels: blocked,dependencies,no stale
+          stale-pr-message: >-
+            No activity here for 30 days, so this is now marked stale. A comment
+            or a push clears the label and restarts the clock. Without one, this
+            closes in 14 days.
+          close-pr-message: >-
+            Closed after 44 days without activity. That is queue cleaning rather
+            than a verdict on the change: the branch is untouched, and a comment
+            here is enough to get this reopened.
+          # Reporting only until the `no stale` label exists, since it is the
+          # sole opt-out for work in progress that should outlive the timer.
+          debug-only: true

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
   "timezone": "Europe/London",
   "reviewers": ["alunduil"],
+  "labels": ["dependencies"],
   "pre-commit": {"enabled": true},
   "minimumReleaseAge": "3 days",
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
## Summary

Pull requests that go quiet get a warning at 30 days and close 14 days
later; any comment or push restarts the clock. Tighter than the usual 90
day convention because Renovate lands here most days, so a branch left a
season is conflicted before anyone asks about it. Issues are excluded.

Refs #453

## Gotchas

- `days-before-issue-close: -1` reads as redundant beside the stale leg
  and is not. #429, #430, #433 and #435 still carry `no-issue-activity`
  from the bot removed in #453, and excluding issues from staling does
  not exclude them from closing.
- Exempting `dependencies` is correctness, not courtesy: Renovate reads a
  closed pull request as "never offer this update again".
- Live on merge, and `no stale` does not exist until
  alunduil/alunduil-infrastructure#330 lands, leaving `blocked` as the
  only opt-out. The five drafts from 8 July go stale around 7 August.

## Test plan

- `pre-commit run` on both files, `renovate-config-validator` included.
- Inputs checked against `actions/stale` v11 `action.yml`: no author
  exemption and no drafts-only selector, hence excluding Renovate by
  label and one clock for drafts.
- Not run: `actionlint`, not a hook here (#559) and not on this host.