### PR TITLE
build: make dependency constraints deliberate

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -735,4 +735,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "2525380a044bb4d3f7d5983f9163b36b1b9246134b637f5e5a4499f236035600"
+content-hash = "36052a461d9a1bd1a6f12194b645a0a85a39c473146724df4c3d455c04ab9f85"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,15 +44,10 @@ packages = [{include = "zfs"}, {include = "zfs_test", format = "sdist"}]
 requires-poetry = ">=2.0"
 
 [tool.poetry.dependencies]
-# Floor: EnumChoice subclasses click.Choice[str], and Choice became
-# subscriptable in 8.2, so older click fails at import rather than at
-# type-check time. Ceiling: CI only ever exercises the locked version, so this
-# bound is the sole protection for a consumer resolving newer click than
-# anything tested here.
+# click.Choice became subscriptable in 8.2, which EnumChoice requires. The
+# ceilings guard click-log, which declares no click bound of its own and is
+# dormant upstream, so a major bump on either side has no upstream fix.
 click = ">=8.2,<9"
-# 0.4.0 has stood since 2022-03 and click-log declares no click bound of its
-# own. A 0.5.0 would be a resurrection rather than an increment, so it does not
-# inherit the compatibility assumption.
 click-log = ">=0.4.0,<0.5"
 python = "^3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,16 @@ packages = [{include = "zfs"}, {include = "zfs_test", format = "sdist"}]
 requires-poetry = ">=2.0"
 
 [tool.poetry.dependencies]
-click = "^8.2"
-click-log = "^0.4.0"
+# Floor: EnumChoice subclasses click.Choice[str], and Choice became
+# subscriptable in 8.2, so older click fails at import rather than at
+# type-check time. Ceiling: CI only ever exercises the locked version, so this
+# bound is the sole protection for a consumer resolving newer click than
+# anything tested here.
+click = ">=8.2,<9"
+# 0.4.0 has stood since 2022-03 and click-log declares no click bound of its
+# own. A 0.5.0 would be a resurrection rather than an increment, so it does not
+# inherit the compatibility assumption.
+click-log = ">=0.4.0,<0.5"
 python = "^3.10"
 
 [tool.poetry.group.test.dependencies]

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Pin the test group so Poetry cannot resolve past the version Renovate targeted, which fails the artifact update whenever a newer release is still inside the bake. :pinDevDependencies from config:best-practices misses it: that preset matches only the devDependencies, dev-dependencies, and dev depTypes, and a Poetry group's depType is its name",
+      "description": "Poetry resolves the newest release in range rather than the version Renovate targeted, so an in-range update writes a lockfile Renovate then rejects. :pinDevDependencies does not reach this group: it matches the devDependencies, dev-dependencies, and dev depTypes, and a Poetry group's depType is its name",
       "matchDepTypes": ["test"],
       "rangeStrategy": "pin"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,11 @@
         "replacement"
       ],
       "minimumReleaseAge": null
+    },
+    {
+      "description": "Pin the test group so Poetry cannot resolve past the version Renovate targeted, which fails the artifact update whenever a newer release is still inside the bake. :pinDevDependencies from config:best-practices misses it: that preset matches only the devDependencies, dev-dependencies, and dev depTypes, and a Poetry group's depType is its name",
+      "matchDepTypes": ["test"],
+      "rangeStrategy": "pin"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Renovate can no longer commit a lockfile that contradicts its own pull request.
Pinning the test group makes Poetry resolve the version Renovate targeted rather
than whatever is newest, the mismatch that failed `renovate/artifacts` on #552.
That one has since been autoclosed, so this prevents recurrence.

The runtime bounds now record why they exist. Both keep the meaning they had.

Refs #552, #571

## Gotchas

- `:pinDevDependencies` from `config:best-practices` looks like it already
  covers this, but it matches only the `devDependencies`, `dev-dependencies`,
  and `dev` depTypes, and a Poetry group's depType is its name. Do not widen
  past `matchDepTypes: ["test"]`: pinning `dependencies` would put exact
  versions in `Requires-Dist`.
- `>=8.2,<9` and `^8.2` are identical, as are `>=0.4.0,<0.5` and `^0.4.0`. Only
  the spelling and the rationale change.

## Test plan

- Installed click 8.1.8 against the tree to confirm the `click` floor is
  load-bearing rather than inherited: `import zfs.replicate.cli.click` fails
  with `TypeError: 'type' object is not subscriptable`. The suite passes at the
  floors, click 8.2.0 and click-log 0.4.0, on Python 3.10.
