### PR TITLE
ci: align stale sweep with alunduil-chezmoi

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,6 +1,6 @@
 name: Daily
 
-# Offset from the hour: on-the-hour schedules queue behind platform peak load.
+# On-the-hour schedules queue behind platform peak load.
 on:
   schedule:
     - cron: '47 6 * * *'
@@ -26,8 +26,8 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      # Both issue legs are disabled, not just marking: an issue already
-      # carrying the label would otherwise stay eligible for closing.
+      # An issue already carrying the label would otherwise stay eligible for
+      # closing.
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
         with:
           days-before-issue-stale: -1

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,17 +1,18 @@
 name: Daily
 
+# Offset from the hour: on-the-hour schedules queue behind platform peak load.
 on:
-  # Offset from the hour deliberately: schedules landing on the hour queue
-  # behind the platform's peak load.
   schedule:
     - cron: '47 6 * * *'
-      timezone: 'Europe/London'
+      timezone: Europe/London
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
+  # No cancel-in-progress: a truncated sweep loses the operations-per-run
+  # resume cache and restarts from the first pull request.
   group: ${{ github.workflow }}
 
 jobs:
@@ -20,16 +21,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
-      # The action's README also asks for `actions: write`, which covers only
-      # its operations-per-run resume cache. Without that scope a truncated run
-      # warns and restarts from the first pull request instead of failing.
+      # `actions: write` is omitted: it covers only the resume cache, so a
+      # truncated run warns and restarts rather than failing.
       issues: write
       pull-requests: write
     steps:
-      # Issues are out of scope on both legs (#453). The previous bot re-closed
-      # #359 after it had been deliberately reopened, and four open issues still
-      # carry `no-issue-activity` from it. Excluding them from staling alone
-      # would leave those four eligible for closing on the next run.
+      # Both issue legs are disabled, not just marking: an issue already
+      # carrying the label would otherwise stay eligible for closing.
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
         with:
           days-before-issue-stale: -1
@@ -37,12 +35,10 @@ jobs:
           days-before-pr-stale: 30
           days-before-pr-close: 14
           stale-pr-label: no-pr-activity
-          # Closing a Renovate pull request tells Renovate the update is
-          # unwanted and it will not offer that version again, so `dependencies`
-          # is a correctness exemption rather than a courtesy one. `no stale` is
-          # the manual opt-out and stays inert until that label is declared in
-          # alunduil/alunduil-infrastructure#330.
-          exempt-pr-labels: blocked,dependencies,no stale
+          # Closing a Renovate pull request tells Renovate the version is
+          # unwanted and it will not re-offer it. Renovate labels nothing by
+          # default, so this depends on renovate.json applying the label.
+          exempt-pr-labels: blocked,dependencies
           stale-pr-message: >-
             This has been quiet for 30 days, so it's picked up a stale label. A
             comment or a push clears the label and restarts the clock. Otherwise


### PR DESCRIPTION
## Summary

Three repos run this stale sweep, and this copy carried an earlier revision of
its comments. The first commit adopts alunduil-chezmoi's wording. The second
goes past it, cutting two comment prefixes that restate the line beneath them,
so the rationale is the only thing left in them. One behaviour change: `no
stale` leaves the exemptions.

## Gotchas

- The file no longer matches its siblings, on purpose. The comment tightening
  is filed against both copies as alunduil/alunduil-chezmoi#548 and
  alunduil/alunduil-infrastructure#359, and either can close by taking this
  wording. Review the second commit as the proposal those two issues describe.
- `no stale` was inert. The label is not declared on this repo, and the comment
  justifying it pointed at unlanded work in
  alunduil/alunduil-infrastructure#330. Revert that line if you would rather
  hold the slot open.
- `stale-pr-label: no-pr-activity` and the `blocked` exemption stay, and are
  deliberately *not* matched to chezmoi. Both name labels that exist here and
  not there, so they are repo configuration rather than drift.
- Extracting all three copies into a reusable `workflow_call` workflow is
  tracked in alunduil/alunduil-infrastructure#358 and subsumes both of the
  above. Merging this does not depend on it.