### PR TITLE
test: give every test package an __init__.py

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -8,8 +8,8 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
 
 - A test module mirrors the module under test, with `_test` appended to every
   path segment, directories and file alike.
-- Each test package directory carries an `__init__.py`. Two older directories
-  (`cli_test/`, `task_test/`) predate this and lack one; new directories add it.
+- Each test package directory carries an `__init__.py` with a one-line
+  docstring naming the package under test.
 
 ## Imports and assertions
 

--- a/zfs_test/replicate_test/cli_test/__init__.py
+++ b/zfs_test/replicate_test/cli_test/__init__.py
@@ -1,0 +1,1 @@
+"""zfs.replicate.cli tests."""

--- a/zfs_test/replicate_test/task_test/__init__.py
+++ b/zfs_test/replicate_test/task_test/__init__.py
@@ -1,0 +1,1 @@
+"""zfs.replicate.task tests."""


### PR DESCRIPTION
## Summary

`zfs_test/replicate_test/cli_test/` and `task_test/` were the last two test
directories without an `__init__.py`. `docs/reference/testing.md:11-12` stated
the convention and then named these two as exceptions, which documented the debt
instead of closing it. Adding the files lets the rule stand on its own.

Both carry a one-line docstring naming the package under test, matching the four
`__init__.py` files that already exist.

## Gotchas

An empty `__init__.py` would fail `ruff`'s `D104`. `pyproject.toml:80` selects
the `D` (pydocstyle) rules and `__init__.py` counts as a public package, so the
docstring is required rather than decorative.

Docstring wording follows the majority form, `<dotted module path> tests.`, used
by `zfs_test/`, `zfs_test/replicate_test/`, and `snapshot_test/`.
`receive_test/__init__.py` uses a different phrasing; I left it alone rather than
widen this change.

## Test plan

`poetry run pytest` collects and passes 50 tests, unchanged from before. Test
count is the thing worth watching here, since adding `__init__.py` to a
previously-namespace package directory is what would alter `pytest` collection
or its rootdir handling.

`pre-commit run --all-files` passes.
