### PR TITLE
docs: move send and receive walkthroughs into a how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,37 +62,13 @@ _N.B., don't use the root user to access your remote system._
 1. `poetry install`
 1. `poetry run -- zfs-replicate --help`
 
+To change what `zfs send` puts on the wire or what `zfs receive` does with it,
+see [How to tune the send and receive streams][stream tuning].
+
 Nix and NixOS users install the `zfs-replicate` package from [nixpkgs] rather
 than building from this repository. NixOS also provides a
 `services.zfs.autoReplication` module that runs replication as a system
 service.
-
-## Setting properties on the replica
-
-To match your destination's policy without a post-receive patch-up, set ZFS
-properties on the received data set with `--receive-set KEY=VALUE` (repeatable)
-and control mounting with `--receive-no-mount`. For example, to set the replica
-`readonly` and keep it from mounting on the destination:
-
-```bash
-zfs-replicate --receive-no-mount --receive-set readonly=on --receive-set canmount=noauto \
-  -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
-```
-
-See `zfs-replicate --help` for the full set of `--receive-` flags.
-
-## Tuning the send stream
-
-To replicate a large-block, already-compressed data set without re-reading or
-recompressing it on the way out, tune the `zfs send` stream with the `--send-`
-flags:
-
-```bash
-zfs-replicate --send-large-block --send-compressed \
-  -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
-```
-
-See `zfs-replicate --help` for the full set of `--send-` flags.
 
 ## Documentation
 
@@ -100,6 +76,8 @@ See `zfs-replicate --help` for the full set of `--send-` flags.
 * [LICENSE]: Licence file explaining usage of zfs-replicate.
 * [How to replicate an encrypted data set][encrypted replication]: Replicate
   without decrypting, then load the replica's key on the destination.
+* [How to tune the send and receive streams][stream tuning]: Set properties on
+  the replica and control what the send stream carries.
 * [Survey of ZFS Replication Tools][survey]: Overview of various ZFS replication
   tools and their uses.
 * [Working With Oracle Solaris ZFS Snapshots and Clones]: Oracle's guide to
@@ -122,6 +100,7 @@ See `zfs-replicate --help` for the full set of `--send-` flags.
 [LICENSE]: ./LICENSE
 [nixpkgs]: https://search.nixos.org/packages?show=zfs-replicate
 [sanoid]: https://github.com/jimsalterjrs/sanoid
+[stream tuning]: ./docs/how-to/tune-the-send-and-receive-streams.md
 [survey]: https://www.reddit.com/r/zfs/comments/7fqu1y/a_small_survey_of_zfs_remote_replication_tools/
 [Working With Oracle Solaris ZFS Snapshots and Clones]: https://docs.oracle.com/cd/E26505_01/html/E37384/gavvx.html#scrolltoc
 [ZFS REMOTE REPLICATION SCRIPT WITH REPORTING]: https://techblog.jeppson.org/2014/10/zfs-remote-replication-script-with-reporting/

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ service.
 * [LICENSE]: Licence file explaining usage of zfs-replicate.
 * [How to replicate an encrypted data set][encrypted replication]: Replicate
   without decrypting, then load the replica's key on the destination.
-* [How to tune the send and receive streams][stream tuning]: Set properties on
-  the replica and control what the send stream carries.
+* [How to tune the send and receive streams][stream tuning]: Control what the
+  send stream carries and set properties on the replica.
 * [Survey of ZFS Replication Tools][survey]: Overview of various ZFS replication
   tools and their uses.
 * [Working With Oracle Solaris ZFS Snapshots and Clones]: Oracle's guide to

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ _N.B., don't use the root user to access your remote system._
 1. `poetry install`
 1. `poetry run -- zfs-replicate --help`
 
-To change what `zfs send` puts on the wire or what `zfs receive` does with it,
-see [How to tune the send and receive streams][stream tuning].
+To tune the send stream or set properties on the replica, see
+[How to tune the send and receive streams][stream tuning].
 
 Nix and NixOS users install the `zfs-replicate` package from [nixpkgs] rather
 than building from this repository. NixOS also provides a

--- a/docs/how-to/tune-the-send-and-receive-streams.md
+++ b/docs/how-to/tune-the-send-and-receive-streams.md
@@ -1,0 +1,47 @@
+# How to tune the send and receive streams
+
+Change what `zfs send` puts on the wire, and what `zfs receive` does with the
+stream on the destination. This assumes you already replicate a data set with
+zfs-replicate.
+
+Run `zfs-replicate --help` for the full set of `--send-` and `--receive-` flags.
+
+## Set properties on the replica
+
+Apply the destination's policy during the receive, so the replica never exists
+in the wrong state. `--receive-set KEY=VALUE` repeats, and `--receive-no-mount`
+keeps the replica from mounting:
+
+```bash
+zfs-replicate --receive-no-mount --receive-set readonly=on --receive-set canmount=noauto \
+  -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
+```
+
+zfs-replicate nests the replica as `REMOTE_FS/POOL/DATA_SET`, so `tank/data`
+lands at `tank/backups/tank/data`. Check the properties there:
+
+```bash
+ssh backup@backup.example.com zfs get readonly,canmount tank/backups/tank/data
+```
+
+## Send large, already-compressed blocks unchanged
+
+Replicate a large-block, compressed data set without re-reading or
+recompressing it on the way out:
+
+```bash
+zfs-replicate --send-large-block --send-compressed \
+  -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
+```
+
+`--send-large-block` requires the `large_blocks` feature on the destination
+pool.
+
+[How to replicate an encrypted data set][encrypted replication] covers
+`--send-raw`, which zfs-replicate passes by default.
+
+[`zfs-send(8)`] and [`zfs-recv(8)`] describe what each underlying flag does.
+
+[encrypted replication]: ./replicate-an-encrypted-data-set.md
+[`zfs-recv(8)`]: https://openzfs.github.io/openzfs-docs/man/master/8/zfs-recv.8.html
+[`zfs-send(8)`]: https://openzfs.github.io/openzfs-docs/man/master/8/zfs-send.8.html

--- a/docs/how-to/tune-the-send-and-receive-streams.md
+++ b/docs/how-to/tune-the-send-and-receive-streams.md
@@ -5,6 +5,21 @@ stream on the destination. This assumes you already replicate a data set with
 zfs-replicate.
 
 Run `zfs-replicate --help` for the full set of `--send-` and `--receive-` flags.
+[`zfs-send(8)`] and [`zfs-recv(8)`] describe what each underlying flag does.
+
+## Send large, already-compressed blocks unchanged
+
+Replicate a large-block, compressed data set without re-reading or
+recompressing it on the way out:
+
+```bash
+zfs-replicate --send-large-block --send-compressed \
+  -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
+```
+
+`--send-large-block` requires the `large_blocks` feature on the destination
+pool. [How to replicate an encrypted data set][encrypted replication] covers
+`--send-raw`, which zfs-replicate passes by default.
 
 ## Set properties on the replica
 
@@ -23,24 +38,6 @@ lands at `tank/backups/tank/data`. Check the properties there:
 ```bash
 ssh backup@backup.example.com zfs get readonly,canmount tank/backups/tank/data
 ```
-
-## Send large, already-compressed blocks unchanged
-
-Replicate a large-block, compressed data set without re-reading or
-recompressing it on the way out:
-
-```bash
-zfs-replicate --send-large-block --send-compressed \
-  -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
-```
-
-`--send-large-block` requires the `large_blocks` feature on the destination
-pool.
-
-[How to replicate an encrypted data set][encrypted replication] covers
-`--send-raw`, which zfs-replicate passes by default.
-
-[`zfs-send(8)`] and [`zfs-recv(8)`] describe what each underlying flag does.
 
 [encrypted replication]: ./replicate-an-encrypted-data-set.md
 [`zfs-recv(8)`]: https://openzfs.github.io/openzfs-docs/man/master/8/zfs-recv.8.html

--- a/docs/how-to/tune-the-send-and-receive-streams.md
+++ b/docs/how-to/tune-the-send-and-receive-streams.md
@@ -1,7 +1,7 @@
 # How to tune the send and receive streams
 
-Change what `zfs send` puts on the wire, and what `zfs receive` does with the
-stream on the destination. This assumes you already replicate a data set with
+Change what `zfs send` includes in the stream, and what `zfs receive` does with
+it on the destination. This assumes you already replicate a data set with
 zfs-replicate.
 
 Run `zfs-replicate --help` for the full set of `--send-` and `--receive-` flags.
@@ -10,22 +10,22 @@ Run `zfs-replicate --help` for the full set of `--send-` and `--receive-` flags.
 ## Send large, already-compressed blocks unchanged
 
 Replicate a large-block, compressed data set without re-reading or
-recompressing it on the way out:
+recompressing it:
 
 ```bash
 zfs-replicate --send-large-block --send-compressed \
   -l backup -i ~/.ssh/id_ed25519 backup.example.com tank/backups tank/data
 ```
 
-`--send-large-block` requires the `large_blocks` feature on the destination
-pool. [How to replicate an encrypted data set][encrypted replication] covers
+The destination pool must have the `large_blocks` feature enabled.
+
+[How to replicate an encrypted data set][encrypted replication] covers
 `--send-raw`, which zfs-replicate passes by default.
 
 ## Set properties on the replica
 
-Apply the destination's policy during the receive, so the replica never exists
-in the wrong state. `--receive-set KEY=VALUE` repeats, and `--receive-no-mount`
-keeps the replica from mounting:
+Set the properties and mount behaviour as the stream lands, rather than fixing
+them afterwards:
 
 ```bash
 zfs-replicate --receive-no-mount --receive-set readonly=on --receive-set canmount=noauto \


### PR DESCRIPTION
## Summary

Tuning guidance now lives at `docs/how-to/tune-the-send-and-receive-streams.md`,
next to the encrypted-replication how-to, instead of accreting a README section
per flag group. The how-to carries the task framing, command and verification
step, and leaves the per-flag reference to `zfs-replicate --help`.

Closes #463

## Gotchas

- #623 restructures the same README headings and says it should assume this
  PR's shape, so it takes any conflict.
- #463 says "There's no `docs/` tree yet" — stale since #642, so this adds one
  file rather than scaffolding a tree.

## Test plan

- Checked each documented flag against `zfs/replicate/cli/options.py` at HEAD.
- Resolved both relative links.
