### PR TITLE
test: vary filesystem names in SNAPSHOTS

### DIFF
--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -16,7 +16,13 @@ from zfs.replicate.snapshot.type import Snapshot
 
 _NOT_WHITESPACE = [x for x in string.printable if x not in string.whitespace and x != "@"]
 
-_FILESYSTEMS = text(_NOT_WHITESPACE).map(lambda x: f"a{x}").map(filesystem)
+
+def _non_empty_name(suffix: str) -> str:
+    """Prefix generated text so the filesystem name is never empty."""
+    return f"a{suffix}"
+
+
+_FILESYSTEMS = text(_NOT_WHITESPACE).map(_non_empty_name).map(filesystem)
 
 _SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
     "filesystem": _FILESYSTEMS,

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -16,7 +16,7 @@ from zfs.replicate.snapshot.type import Snapshot
 
 _NOT_WHITESPACE = [x for x in string.printable if x not in string.whitespace and x != "@"]
 
-_FILESYSTEMS = text(_NOT_WHITESPACE).map(lambda x: "a{x}").map(filesystem)
+_FILESYSTEMS = text(_NOT_WHITESPACE).map(lambda x: f"a{x}").map(filesystem)
 
 _SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
     "filesystem": _FILESYSTEMS,

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -14,7 +14,9 @@ from hypothesis.strategies import (
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.type import Snapshot
 
-_NOT_WHITESPACE = [x for x in string.printable if x not in string.whitespace and x != "@"]
+# zfs list -H separates fields with \t and records with \n, and @ splits the filesystem from the
+# snapshot name, so a generated name holding any of them cannot survive _snapshots parsing it back.
+_ROUND_TRIP_SAFE = [x for x in string.printable if x not in string.whitespace and x != "@"]
 
 
 def _non_empty_name(suffix: str) -> str:
@@ -22,11 +24,11 @@ def _non_empty_name(suffix: str) -> str:
     return f"a{suffix}"
 
 
-_FILESYSTEMS = text(_NOT_WHITESPACE).map(_non_empty_name).map(filesystem)
+_FILESYSTEMS = text(_ROUND_TRIP_SAFE).map(_non_empty_name).map(filesystem)
 
 _SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
     "filesystem": _FILESYSTEMS,
-    "name": text(_NOT_WHITESPACE),
+    "name": text(_ROUND_TRIP_SAFE),
     "timestamp": integers(),
     "previous": none(),
 }

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -14,13 +14,11 @@ from hypothesis.strategies import (
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.type import Snapshot
 
-# zfs list -H separates fields with \t and records with \n, and @ splits the filesystem from the
-# snapshot name, so a generated name holding any of them cannot survive _snapshots parsing it back.
+# zfs list -H separates fields with \t and records with \n, and @ splits the filesystem from the snapshot name.
 _ROUND_TRIP_SAFE = [x for x in string.printable if x not in string.whitespace and x != "@"]
 
 
 def _non_empty_name(suffix: str) -> str:
-    """Prefix generated text so the filesystem name is never empty."""
     return f"a{suffix}"
 
 

--- a/zfs_test/replicate_test/snapshot_test/strategies_test.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies_test.py
@@ -10,6 +10,10 @@ from zfs.replicate.snapshot.type import Snapshot
 
 def test_snapshots_vary_filesystem() -> None:
     """SNAPSHOTS draws more than one filesystem name."""
+    assert len(_drawn_filesystem_names()) > 1
+
+
+def _drawn_filesystem_names() -> Set[str]:
     names: Set[str] = set()
 
     @given(sut.SNAPSHOTS)
@@ -18,4 +22,4 @@ def test_snapshots_vary_filesystem() -> None:
 
     collect()
 
-    assert len(names) > 1
+    return names

--- a/zfs_test/replicate_test/snapshot_test/strategies_test.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies_test.py
@@ -1,0 +1,21 @@
+"""zfs_test.replicate_test.snapshot_test.strategies tests."""
+
+from typing import Set
+
+from hypothesis import given
+
+import zfs_test.replicate_test.snapshot_test.strategies as sut
+from zfs.replicate.snapshot.type import Snapshot
+
+
+def test_snapshots_vary_filesystem() -> None:
+    """SNAPSHOTS draws more than one filesystem name."""
+    names: Set[str] = set()
+
+    @given(sut.SNAPSHOTS)
+    def collect(snapshot: Snapshot) -> None:
+        names.add(snapshot.filesystem.name)
+
+    collect()
+
+    assert len(names) > 1


### PR DESCRIPTION
## Summary

`SNAPSHOTS` now draws varied filesystem names. `_FILESYSTEMS` mapped every draw through the plain literal `"a{x}"` instead of an f-string, so every generated snapshot named the same filesystem and the property tests built on it (list parser, planner, generator) only ever saw a single-filesystem world. The two names the fix depends on now say what they mean: the prefix mapping became `_non_empty_name`, and the character set became `_ROUND_TRIP_SAFE`. Closes #405.

## Gotchas

- The production fix is one character and no existing test changes behaviour: all 68 passed before and after. CI staying green says nothing about whether the strategy works, which is why `strategies_test.py` exists as the only sensor for a collapsed strategy. It asserts across a whole Hypothesis run rather than per example, so the drawing lives in `_drawn_filesystem_names()` and the test body is just the claim.
- `_NOT_WHITESPACE` → `_ROUND_TRIP_SAFE` is a pure rename over two use sites; the comprehension it names is byte-for-byte unchanged. The comment above it names the three separators, and the reason they matter is this: `_snapshot` splits a `zfs list -H` line on `\t` and then splits the name on `@` with no maxsplit, so a generated name carrying either raises `ValueError` rather than round-tripping.
- The acceptance criterion anticipating newly-failing tests didn't fire: #651 (5219fed) already replaced `str.replace("/", "")` with `removeprefix`, so generated names containing slashes survive intact.

## Test plan

- `poetry run pytest` on 5219fed: 68 passed. After the change: 69 passed.
- Reverted the f-string and re-ran the new test, both before and after extracting `_non_empty_name`: fails with `AssertionError: assert 1 > 1` each time, so the guard is not decoration and the extraction didn't blunt it.
- `pre-commit run --all-files`: all hooks passed.

Follow-up: #655 tracks replacing `fixed_dictionaries(...).map(...)` with `builds(Snapshot, ...)`, left out of here to keep this PR to one concern.
