### PR TITLE
refactor: return a named pair from compress.command

### DIFF
--- a/zfs/replicate/compress/command.py
+++ b/zfs/replicate/compress/command.py
@@ -1,20 +1,39 @@
 """ZFS Replication Compression Command Mapping."""
 
-from typing import Optional, Tuple
+from dataclasses import dataclass
+from typing import Optional
 
 from ..command import Command
 from .type import Compression
 
 
-def command(compression: Compression) -> Tuple[Optional[Command], Optional[Command]]:
+@dataclass(frozen=True)
+class Commands:
+    """The pair of commands a compression stage needs.
+
+    The two are not interchangeable: ``compress`` runs locally on the sending
+    side, ``decompress`` runs on the far side of ssh. Naming the slots keeps a
+    call site from transposing them, and making both fields required means a
+    half-configured stage cannot be built. Compression is on or off, never
+    one-sided.
+    """
+
+    compress: Command
+    decompress: Command
+
+
+def command(compression: Compression) -> Optional[Commands]:
     """Map a compression to its local compress and remote decompress commands.
 
-    ``OFF`` yields ``(None, None)`` -- no compression stage.
+    ``OFF`` yields ``None`` -- no compression stage.
     """
     if compression == Compression.LZ4:
-        return (Command.with_empty_env("lz4"), Command.with_empty_env("lz4", "-d"))
+        return Commands(
+            compress=Command.with_empty_env("lz4"),
+            decompress=Command.with_empty_env("lz4", "-d"),
+        )
 
     if compression == Compression.OFF:
-        return (None, None)
+        return None
 
     raise ValueError(f"invalid compression: '{compression}'", compression)

--- a/zfs/replicate/compress/command.py
+++ b/zfs/replicate/compress/command.py
@@ -9,13 +9,11 @@ from .type import Compression
 
 @dataclass(frozen=True)
 class Commands:
-    """The pair of commands a compression stage needs.
+    """The two halves of a compression stage, one per side of the ssh boundary.
 
-    The two are not interchangeable: ``compress`` runs locally on the sending
-    side, ``decompress`` runs on the far side of ssh. Naming the slots keeps a
-    call site from transposing them, and making both fields required means a
-    half-configured stage cannot be built. Compression is on or off, never
-    one-sided.
+    ``compress`` runs locally on the sending side; ``decompress`` runs remotely,
+    ahead of ``zfs receive``. Compression is on or off, never one-sided, so a
+    stage always carries both.
     """
 
     compress: Command

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -72,23 +72,19 @@ def _pipeline(  # noqa: PLR0913 -- carries the full replication call surface
     previous: Optional[Snapshot] = None,
 ) -> Pipeline:
     """Assemble the pipeline that replicates ``current`` onto ``remote``, spawning nothing."""
-    compression_commands = compress.command(compression)
-
-    compress_command: Optional[Command] = None
-    decompress_command: Optional[Command] = None
-
-    if compression_commands is not None:
-        compress_command = compression_commands.compress
-        decompress_command = compression_commands.decompress
-
+    send_command = _send(current, previous, options=send_options)
     destination = filesystem.remote_dataset(remote, current.filesystem)
+    receive = receive_command(destination, receive_options)
 
-    remote_side = optional.values(decompress_command, receive_command(destination, receive_options))
+    commands = compress.command(compression)
+
+    if commands is None:
+        return Pipeline(send=send_command, compress=None, receive=over_ssh(ssh_command, receive))
 
     return Pipeline(
-        send=_send(current, previous, options=send_options),
-        compress=compress_command,
-        receive=over_ssh(ssh_command, *remote_side),
+        send=send_command,
+        compress=commands.compress,
+        receive=over_ssh(ssh_command, commands.decompress, receive),
     )
 
 

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -72,7 +72,14 @@ def _pipeline(  # noqa: PLR0913 -- carries the full replication call surface
     previous: Optional[Snapshot] = None,
 ) -> Pipeline:
     """Assemble the pipeline that replicates ``current`` onto ``remote``, spawning nothing."""
-    compress_command, decompress_command = compress.command(compression)
+    compression_commands = compress.command(compression)
+
+    compress_command: Optional[Command] = None
+    decompress_command: Optional[Command] = None
+
+    if compression_commands is not None:
+        compress_command = compression_commands.compress
+        decompress_command = compression_commands.decompress
 
     destination = filesystem.remote_dataset(remote, current.filesystem)
 


### PR DESCRIPTION
## Summary

`compress.command` returns `Optional[Commands]`, a frozen dataclass with
required `compress` and `decompress` fields, retiring a bare
`Tuple[Optional[Command], Optional[Command]]` whose two `None`s were correlated
and whose slots were unnamed but not interchangeable. `snapshot._pipeline`
branches once on the whole result. No behaviour change.

Closes #475

## Gotchas

- `Commands` sits in `compress/command.py`, not `compress/type.py` where the
  package's other type lives. It follows `Pipeline` in `snapshot/send.py`: a
  return-type value object kept beside the one function that builds it.
- `_pipeline` constructs `Pipeline` in both branches deliberately — that is what
  removes the mutable optional temps. The remote side drops `optional.values`
  because `over_ssh` is already variadic.
- No test changes. `compress.command`'s totality test and `snapshot.send`'s
  OFF/LZ4 assertions already cover both branches.
