### PR TITLE
docs(agents): trim CLAUDE.md and fix two gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,25 +5,24 @@
 Reach for these before writing a `curl` call, a manual API
 request, or a one-off `Bash` helper.
 
-- **Package manager:** `Poetry`. `pyproject.toml` is the source
-  of truth, `poetry.lock` pins the resolved versions, and
-  `poetry.toml` carries `Poetry` settings.
-- **Development shell:** `.devcontainer/`, bootstrapped by
-  `.devcontainer/post-create.sh`. No `Nix` expressions live
-  here: `nixpkgs` packages `zfs-replicate` upstream, so a local
-  derivation would be a second definition to keep in sync
+- **Dependencies:** `Poetry`, resolved from `pyproject.toml`.
+- **Development shell:** `.devcontainer/`. No `Nix` expressions
+  live here: `nixpkgs` packages `zfs-replicate` upstream, so a
+  local derivation would be a second definition to keep in sync
   (#430).
-- **Tests:** `pytest` over `zfs_test/`, configured under
-  `[tool.pytest.ini_options]`. `--doctest-modules` runs every
-  docstring example in `zfs/` as a test. `Hypothesis` is a
-  development dependency.
-- **Lint and format:** `ruff` (lint and format), `mypy`
-  (types), `Vale` (prose), `vulture` (dead code), and
-  `FawltyDeps` (unused dependencies), each gated through
-  `pre-commit`. Run `pre-commit run --all-files` as the
-  canonical local check.
-- **Entry point:** the command-line tool installs as
-  `zfs-replicate = "zfs.replicate.cli.main:main"`.
+- **Tests:** `pytest` over `zfs_test/`. The conventions it
+  follows, from the `sut` import alias to when a property test
+  beats a fixed input, live in
+  [docs/reference/testing.md](docs/reference/testing.md).
+- **Lint, format, and types:** match `ruff` and `mypy` when
+  writing code. `pre-commit run --all-files` is the canonical
+  local check, and `.pre-commit-config.yaml` lists everything
+  else it gates.
+- **Entry point:** `zfs.replicate.cli.main:main`, installed as
+  `zfs-replicate`.
+- **Session setup:** a `SessionStart` hook already ran `poetry
+  install` and `pre-commit install`. Machine-specific overrides
+  belong in `.claude/settings.local.json`.
 
 ## Scope discipline
 
@@ -33,20 +32,12 @@ request, or a one-off `Bash` helper.
   If it might, ask in the issue thread.
 - Milestones don't gate work. `release-please` cuts releases
   from merged commits, so a later milestone is no reason to
-  defer an issue. An unreleased prerequisite is, and belongs
-  on a `blocked-by` edge.
+  defer an issue. An unreleased prerequisite is, and belongs on
+  a `blocked-by` edge.
 
 ## Commit and pull request conventions
 
 Squash merge lands the pull request title as the commit
-message, so the title is what `release-please` parses for the
-version bump. Both follow the conventional-commit rules in
+message, so the title is the string `release-please` parses for
+the version bump. Both follow
 [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages).
-
-## Session defaults
-
-A `SessionStart` hook in `.claude/settings.json` runs `poetry
-install` and `pre-commit install`, so dependencies and git
-hooks are ready before the first turn. Machine-specific
-overrides belong in `.claude/settings.local.json`, which
-`.gitignore` excludes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,86 +1,52 @@
 # Project guide for Claude Code
 
-This file gives Claude Code (and similar coding agents) the
-project-local context it needs to land changes that fit the
-conventions here. Two friction patterns surfaced during a
-recent `/insights` review and motivated this file (see issue
-#445): agents reaching for `curl` and first-principles
-scripts when local tools already cover the task, and agents
-bleeding scope across linked or sibling issues.
-
 ## Tool inventory
 
-The first move when picking up a task should be discovering
-what's already wired into the project, not reinventing it.
+Reach for these before writing a `curl` call, a manual API
+request, or a one-off `Bash` helper.
 
-- **Package manager:** `Poetry`. `pyproject.toml` is the
-  source of truth; `poetry.lock` pins the resolved versions;
+- **Package manager:** `Poetry`. `pyproject.toml` is the source
+  of truth, `poetry.lock` pins the resolved versions, and
   `poetry.toml` carries `Poetry` settings.
-- **Development shell:** `.devcontainer/` covers Visual Studio
-  Code and GitHub `Codespaces`;
-  `.devcontainer/post-create.sh` bootstraps the container. This
-  project carries no `Nix` expressions: `nixpkgs` packages
-  `zfs-replicate` upstream, so a local derivation would be a
-  second definition to keep in sync (see #430).
-- **Tests:** `pytest` with `--doctest-modules --cov=zfs
-  --cov-report=term-missing` (configured under
-  `[tool.pytest.ini_options]` in `pyproject.toml`). The test
-  tree lives under `zfs_test/`. `Hypothesis` is available as
-  a development dependency.
-- **Lint and format:** `ruff` (both `ruff check` and `ruff
-  format`), configured under `[tool.ruff]` in `pyproject.toml`.
-  It covers what `black`, `isort`, `flake8`, `pydocstyle`, and
-  `bandit` used to. `mypy` (`[tool.mypy]`) covers types, `Vale`
-  (`.vale.ini`, `styles/`) prose, `vulture` dead code, and
-  `FawltyDeps` unused dependencies. `pre-commit` runs all of
-  them from `.pre-commit-config.yaml`; `pre-commit run
-  --all-files` is the canonical local check.
+- **Development shell:** `.devcontainer/`, bootstrapped by
+  `.devcontainer/post-create.sh`. No `Nix` expressions live
+  here: `nixpkgs` packages `zfs-replicate` upstream, so a local
+  derivation would be a second definition to keep in sync
+  (#430).
+- **Tests:** `pytest` over `zfs_test/`, configured under
+  `[tool.pytest.ini_options]`. `--doctest-modules` runs every
+  docstring example in `zfs/` as a test. `Hypothesis` is a
+  development dependency.
+- **Lint and format:** `ruff` (lint and format), `mypy`
+  (types), `Vale` (prose), `vulture` (dead code), and
+  `FawltyDeps` (unused dependencies), each gated through
+  `pre-commit`. Run `pre-commit run --all-files` as the
+  canonical local check.
 - **Entry point:** the command-line tool installs as
-  `zfs-replicate = "zfs.replicate.cli.main:main"` (see
-  `[tool.poetry.scripts]` in `pyproject.toml`).
-
-Use these before hand-rolling alternatives. If a task feels
-as though it needs `curl`, a manual API call, or a one-off
-`Bash` helper, check the inventory first; the local tool that
-already covers it produces less churn for reviewers.
+  `zfs-replicate = "zfs.replicate.cli.main:main"`.
 
 ## Scope discipline
 
-When working from numbered issues:
+- Keep one concern per pull request. Revert incidental edits
+  before requesting review.
+- Confirm the scope doesn't overlap a linked or sibling issue.
+  If it might, ask in the issue thread.
+- Milestones don't gate work. `release-please` cuts releases
+  from merged commits, so a later milestone is no reason to
+  defer an issue. An unreleased prerequisite is, and belongs
+  on a `blocked-by` edge.
 
-- Before opening a pull request, confirm the scope doesn't
-  overlap with linked or sibling issues. If it might, ask in
-  the issue thread instead of guessing.
-- If an issue is blocked by an unreleased prerequisite, propose
-  deferral with a `blocked-by` edge rather than writing
-  premature code that will need to be reworked.
-- Revert any out-of-scope incidental edits before requesting
-  review. One concern per pull request.
+## Commit and pull request conventions
 
-Most of this is encoded in the `issue-work` skill already;
-this note exists so that Claude applies the discipline
-without having to call the skill explicitly.
-
-## Why this project specifically
-
-GitHub lists the open release milestones, and the active
-`blocked` label signals that sequencing matters here. Clear
-scope discipline avoids prematurely shipping something blocked
-by an earlier milestone. The Python tool stack (`ruff` for
-lint and format, `mypy` for types, all gated through
-`pre-commit`) is one an agent can plausibly reinvent unless the
-inventory is in front of it.
+Squash merge lands the pull request title as the commit
+message, so the title is what `release-please` parses for the
+version bump. Both follow the conventional-commit rules in
+[CONTRIBUTING.md](CONTRIBUTING.md#commit-messages).
 
 ## Session defaults
 
-`.claude/settings.json` ships committed Claude Code defaults
-so agent sessions start productive. A `SessionStart` hook runs
-`poetry install` and `pre-commit install`, mirroring
-`.devcontainer/post-create.sh`, so the environment and git
-hooks are ready before the first turn. The `permissions.allow`
-list pre-approves the inspection commands an agent reaches for
-early: `poetry run pytest`, `pre-commit run`, `poetry run
-zfs-replicate --help`, and `git diff`, `git log`, `git
-status`, and `git show`. Machine-specific overrides go in
-`.claude/settings.local.json`, which `.gitignore` keeps out of
-version control.
+A `SessionStart` hook in `.claude/settings.json` runs `poetry
+install` and `pre-commit install`, so dependencies and git
+hooks are ready before the first turn. Machine-specific
+overrides belong in `.claude/settings.local.json`, which
+`.gitignore` excludes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,7 @@ request, or a one-off `Bash` helper.
 - **Dependencies:** `Poetry`, resolved from `pyproject.toml`.
 - **Development shell:** `.devcontainer/`. No `Nix` expressions
   live here: `nixpkgs` packages `zfs-replicate` upstream, so a
-  local derivation would be a second definition to keep in sync
-  (#430).
+  local derivation would be a second definition to keep in sync.
 - **Tests:** `pytest` over `zfs_test/`. The conventions it
   follows, from the `sut` import alias to when a property test
   beats a fixed input, live in


### PR DESCRIPTION
## Summary

`CLAUDE.md` goes from 531 words to 234. Three passes: cut the prose that carried history or justification instead of instructions, replace the data this file copied from other files with pointers to the files that own it, then drop the one issue number left in the prose. Closes #477.

The second pass came from reading `CLAUDE.md` for duplication the way Fowler's catalogue reads code. The pytest addopts, the pre-commit hook roster, and the prose account of the `SessionStart` hook were each a copy that drifts on its own schedule, and one already had: the entry-point bullet cited `[tool.poetry.scripts]` while `pyproject.toml:18` has read `[project.scripts]` since the packaging move.

## Gotchas

- The deleted "Why this project specifically" section told agents that open milestones and the `blocked` label signal sequencing, which reads as license to defer an issue parked on a later milestone. `release-please` cuts releases from merged commits, so the replacement line says the opposite: a reversal, not a trim.
- The lint bullet no longer names `vulture`, `FawltyDeps`, or `Vale`. The line kept is that a tool name earns a mention only when it changes a choice an agent makes: `ruff` and `mypy` say don't reach for `black` or `flake8`, while the other three are never an agent's pick and `pre-commit` can introduce them.
- Net of the cuts, the diff adds two things. `docs/reference/testing.md` was never referenced from `CLAUDE.md` despite owning the `sut` alias, the `_test` mirroring rule, and the property-test policy an agent needs before writing a test. And squash merge makes the pull request title the string `release-please` parses, which `CONTRIBUTING.md` doesn't say (it describes commit messages on `main`) and `.github/copilot/` says only to a reader Claude sessions don't have.
- #476 (excluding this file from Vale) is still open, so `CLAUDE.md` remains linted.

## Test plan

- `pre-commit run --files CLAUDE.md` after each commit: all hooks pass, Vale included.
- Verified every claim the trimmed file still makes against HEAD: `pyproject.toml:18` for the entry point, `.pre-commit-config.yaml` for `ruff` and `mypy`, `docs/reference/testing.md` for the testing conventions, and the `SessionStart` hook in `.claude/settings.json` for `poetry install` / `pre-commit install`.
- Audited the rest of the repository's comments and doc prose against the same standard. Findings outside this file are filed as #665 and #666 rather than folded in here.
