### PR TITLE
fix: clean stderr before reporting a failed destroy

### DIFF
--- a/zfs/replicate/filesystem/create.py
+++ b/zfs/replicate/filesystem/create.py
@@ -6,6 +6,7 @@ from .. import process
 from ..command import Command, over_ssh
 from ..error import ZFSReplicateError
 from ..list import inits
+from ..stderr import clean
 from . import type
 from .list import list
 from .type import FileSystem
@@ -28,7 +29,7 @@ def create(filesystem: FileSystem, ssh_command: Command) -> None:
 
         result = process.run(over_ssh(ssh_command, _create(path)))
 
-        error = result.stderr.strip(b"\n").strip(b"\r").replace(b"WARNING: ENABLED NONE CIPHER", b"")
+        error = clean(result.stderr)
 
         if result.returncode:
             if b"successfully created, but not mounted" in error:

--- a/zfs/replicate/filesystem/create.py
+++ b/zfs/replicate/filesystem/create.py
@@ -29,9 +29,9 @@ def create(filesystem: FileSystem, ssh_command: Command) -> None:
 
         result = process.run(over_ssh(ssh_command, _create(path)))
 
-        error = clean(result.stderr)
-
         if result.returncode:
+            error = clean(result.stderr)
+
             if b"successfully created, but not mounted" in error:
                 return  # Ignore this error.
 

--- a/zfs/replicate/filesystem/destroy.py
+++ b/zfs/replicate/filesystem/destroy.py
@@ -11,9 +11,9 @@ def destroy(filesystem: FileSystem, ssh_command: Command) -> None:
     """Destroy a remote filesystem."""
     result = process.run(over_ssh(ssh_command, _destroy(filesystem)))
 
-    error = clean(result.stderr)
-
     if result.returncode:
+        error = clean(result.stderr)
+
         raise ZFSReplicateError(
             f"unable to destroy dataset: '{filesystem.dataset}': {error!r}",
             filesystem,

--- a/zfs/replicate/filesystem/destroy.py
+++ b/zfs/replicate/filesystem/destroy.py
@@ -3,6 +3,7 @@
 from .. import process
 from ..command import Command, over_ssh
 from ..error import ZFSReplicateError
+from ..stderr import clean
 from .type import FileSystem
 
 
@@ -10,11 +11,13 @@ def destroy(filesystem: FileSystem, ssh_command: Command) -> None:
     """Destroy a remote filesystem."""
     result = process.run(over_ssh(ssh_command, _destroy(filesystem)))
 
+    error = clean(result.stderr)
+
     if result.returncode:
         raise ZFSReplicateError(
-            f"unable to destroy dataset: '{filesystem.dataset}': {result.stderr!r}",
+            f"unable to destroy dataset: '{filesystem.dataset}': {error!r}",
             filesystem,
-            result.stderr,
+            error,
         )
 
 

--- a/zfs/replicate/filesystem/list.py
+++ b/zfs/replicate/filesystem/list.py
@@ -17,9 +17,9 @@ def list(filesystem: FileSystem, ssh_command: Command) -> List[FileSystem]:
     """List ZFS FileSystem on the remote reachable through ``ssh_command``."""
     result = process.run(over_ssh(ssh_command, _list(filesystem)))
 
-    error = clean(result.stderr)
-
     if result.returncode:
+        error = clean(result.stderr)
+
         raise ZFSReplicateError(
             f"error encountered while listing filesystems of '{filesystem.name}': {error!r}",
             filesystem,

--- a/zfs/replicate/filesystem/list.py
+++ b/zfs/replicate/filesystem/list.py
@@ -6,6 +6,7 @@ from typing import List
 from .. import process
 from ..command import Command, over_ssh
 from ..error import ZFSReplicateError
+from ..stderr import clean
 from . import type
 from .type import FileSystem
 
@@ -16,7 +17,7 @@ def list(filesystem: FileSystem, ssh_command: Command) -> List[FileSystem]:
     """List ZFS FileSystem on the remote reachable through ``ssh_command``."""
     result = process.run(over_ssh(ssh_command, _list(filesystem)))
 
-    error = result.stderr.strip(b"\n").strip(b"\r").replace(b"WARNING: ENABLED NONE CIPHER", b"")
+    error = clean(result.stderr)
 
     if result.returncode:
         raise ZFSReplicateError(

--- a/zfs/replicate/snapshot/destroy.py
+++ b/zfs/replicate/snapshot/destroy.py
@@ -11,9 +11,9 @@ def destroy(snapshot: Snapshot, ssh_command: Command) -> None:
     """Destroy a remote snapshot."""
     result = process.run(over_ssh(ssh_command, _destroy(snapshot)))
 
-    error = clean(result.stderr)
-
     if result.returncode:
+        error = clean(result.stderr)
+
         raise ZFSReplicateError(
             f"unable to destroy snapshot: '{snapshot.filesystem.name}@{snapshot.name}': {error!r}",
             snapshot,

--- a/zfs/replicate/snapshot/destroy.py
+++ b/zfs/replicate/snapshot/destroy.py
@@ -3,6 +3,7 @@
 from .. import process
 from ..command import Command, over_ssh
 from ..error import ZFSReplicateError
+from ..stderr import clean
 from .type import Snapshot
 
 
@@ -10,11 +11,13 @@ def destroy(snapshot: Snapshot, ssh_command: Command) -> None:
     """Destroy a remote snapshot."""
     result = process.run(over_ssh(ssh_command, _destroy(snapshot)))
 
+    error = clean(result.stderr)
+
     if result.returncode:
         raise ZFSReplicateError(
-            f"unable to destroy snapshot: '{snapshot.filesystem.name}@{snapshot.name}': {result.stderr!r}",
+            f"unable to destroy snapshot: '{snapshot.filesystem.name}@{snapshot.name}': {error!r}",
             snapshot,
-            result.stderr,
+            error,
         )
 
 

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -6,6 +6,7 @@ from .. import process
 from ..command import Command, over_ssh
 from ..error import ZFSReplicateError
 from ..filesystem import FileSystem, filesystem
+from ..stderr import clean
 from .type import Snapshot
 
 
@@ -21,7 +22,7 @@ def list(
 
     result = process.run(command)
 
-    error = result.stderr.strip(b"\n").strip(b"\r").replace(b"WARNING: ENABLED NONE CIPHER", b"")
+    error = clean(result.stderr)
 
     if result.returncode:
         raise ZFSReplicateError(

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -22,9 +22,9 @@ def list(
 
     result = process.run(command)
 
-    error = clean(result.stderr)
-
     if result.returncode:
+        error = clean(result.stderr)
+
         raise ZFSReplicateError(
             f"error encountered while listing snapshots of '{filesystem.name}': {error!r}",
             filesystem,

--- a/zfs/replicate/stderr.py
+++ b/zfs/replicate/stderr.py
@@ -1,10 +1,9 @@
-r"""Cleanup for stderr captured from a zfs command.
+"""Cleanup for stderr captured from a zfs command.
 
-Two kinds of noise ride along with a command's stderr and do not belong in a
-raised error message: the line endings the shell appends, and the none-cipher
-banner an ssh build that supports it prints when
-:data:`~zfs.replicate.ssh.Cipher.DISABLED` turns encryption off. Every call site
-that reports stderr routes it through :func:`clean` first.
+Captured stderr carries noise that does not belong in a raised error message:
+the line ending the shell appends, and the banner ssh prints when
+:attr:`~zfs.replicate.ssh.Cipher.DISABLED` turns encryption off. Call sites
+route stderr through :func:`clean` before reporting it.
 """
 
 _NONE_CIPHER_WARNING = b"WARNING: ENABLED NONE CIPHER"

--- a/zfs/replicate/stderr.py
+++ b/zfs/replicate/stderr.py
@@ -1,0 +1,22 @@
+r"""Cleanup for stderr captured from a zfs command.
+
+Two kinds of noise ride along with a command's stderr and do not belong in a
+raised error message: the line endings the shell appends, and the none-cipher
+banner an ssh build that supports it prints when
+:data:`~zfs.replicate.ssh.Cipher.DISABLED` turns encryption off. Every call site
+that reports stderr routes it through :func:`clean` first.
+"""
+
+_NONE_CIPHER_WARNING = b"WARNING: ENABLED NONE CIPHER"
+
+
+def clean(error: bytes) -> bytes:
+    r"""Drop line-ending and none-cipher noise from captured stderr.
+
+    >>> clean(b"cannot open 'pool/data': dataset does not exist\n")
+    b"cannot open 'pool/data': dataset does not exist"
+
+    >>> clean(b"WARNING: ENABLED NONE CIPHER\r\n")
+    b''
+    """
+    return error.strip(b"\n").strip(b"\r").replace(_NONE_CIPHER_WARNING, b"")

--- a/zfs/replicate/stderr.py
+++ b/zfs/replicate/stderr.py
@@ -10,7 +10,7 @@ that reports stderr routes it through :func:`clean` first.
 _NONE_CIPHER_WARNING = b"WARNING: ENABLED NONE CIPHER"
 
 
-def clean(error: bytes) -> bytes:
+def clean(stderr: bytes) -> bytes:
     r"""Drop line-ending and none-cipher noise from captured stderr.
 
     >>> clean(b"cannot open 'pool/data': dataset does not exist\n")
@@ -19,4 +19,4 @@ def clean(error: bytes) -> bytes:
     >>> clean(b"WARNING: ENABLED NONE CIPHER\r\n")
     b''
     """
-    return error.strip(b"\n").strip(b"\r").replace(_NONE_CIPHER_WARNING, b"")
+    return stderr.strip(b"\n").strip(b"\r").replace(_NONE_CIPHER_WARNING, b"")

--- a/zfs_test/replicate_test/filesystem_test/__init__.py
+++ b/zfs_test/replicate_test/filesystem_test/__init__.py
@@ -1,0 +1,1 @@
+"""zfs.replicate.filesystem tests."""

--- a/zfs_test/replicate_test/filesystem_test/destroy_test.py
+++ b/zfs_test/replicate_test/filesystem_test/destroy_test.py
@@ -1,0 +1,46 @@
+"""zfs.replicate.filesystem.destroy tests."""
+
+import subprocess
+
+import pytest
+
+from zfs.replicate import process
+from zfs.replicate.command import Command
+from zfs.replicate.error import ZFSReplicateError
+
+# zfs.replicate.filesystem re-exports destroy, so the package attribute is the function,
+# not the module -- import the function rather than aliasing the module as sut.
+from zfs.replicate.filesystem.destroy import destroy
+from zfs.replicate.filesystem.type import filesystem
+
+SSH = Command.with_empty_env("ssh", "host")
+
+
+def _fails_with(monkeypatch: pytest.MonkeyPatch, error: bytes) -> None:
+    def fake_run(command: Command, **_kwargs: object) -> "subprocess.CompletedProcess[bytes]":
+        return subprocess.CompletedProcess(command.argv, 1, b"", error)
+
+    monkeypatch.setattr(process, "run", fake_run)
+
+
+def test_destroy_reports_stderr_without_line_endings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed destroy names the reason without the shell's trailing line ending."""
+    _fails_with(monkeypatch, b"cannot destroy 'pool/data': dataset is busy\r\n")
+
+    with pytest.raises(ZFSReplicateError) as raised:
+        destroy(filesystem("pool/data"), SSH)
+
+    assert "dataset is busy" in raised.value.message
+    assert "\\r" not in raised.value.message
+    assert "\\n" not in raised.value.message
+
+
+def test_destroy_reports_stderr_without_the_none_cipher_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ssh banner does not ride along into a failed destroy's message."""
+    _fails_with(monkeypatch, b"WARNING: ENABLED NONE CIPHERcannot destroy 'pool/data': dataset is busy")
+
+    with pytest.raises(ZFSReplicateError) as raised:
+        destroy(filesystem("pool/data"), SSH)
+
+    assert "dataset is busy" in raised.value.message
+    assert "NONE CIPHER" not in raised.value.message

--- a/zfs_test/replicate_test/filesystem_test/destroy_test.py
+++ b/zfs_test/replicate_test/filesystem_test/destroy_test.py
@@ -7,9 +7,6 @@ import pytest
 from zfs.replicate import process
 from zfs.replicate.command import Command
 from zfs.replicate.error import ZFSReplicateError
-
-# zfs.replicate.filesystem re-exports destroy, so the package attribute is the function,
-# not the module -- import the function rather than aliasing the module as sut.
 from zfs.replicate.filesystem.destroy import destroy
 from zfs.replicate.filesystem.type import filesystem
 
@@ -36,7 +33,7 @@ def test_destroy_reports_stderr_without_line_endings(monkeypatch: pytest.MonkeyP
 
 
 def test_destroy_reports_stderr_without_the_none_cipher_warning(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The ssh banner does not ride along into a failed destroy's message."""
+    """The ssh banner does not reach a failed destroy's message."""
     _fails_with(monkeypatch, b"WARNING: ENABLED NONE CIPHERcannot destroy 'pool/data': dataset is busy")
 
     with pytest.raises(ZFSReplicateError) as raised:

--- a/zfs_test/replicate_test/snapshot_test/destroy_test.py
+++ b/zfs_test/replicate_test/snapshot_test/destroy_test.py
@@ -8,9 +8,6 @@ from zfs.replicate import process
 from zfs.replicate.command import Command
 from zfs.replicate.error import ZFSReplicateError
 from zfs.replicate.filesystem.type import filesystem
-
-# zfs.replicate.snapshot re-exports destroy, so the package attribute is the function,
-# not the module -- import the function rather than aliasing the module as sut.
 from zfs.replicate.snapshot.destroy import destroy
 from zfs.replicate.snapshot.type import Snapshot
 
@@ -38,7 +35,7 @@ def test_destroy_reports_stderr_without_line_endings(monkeypatch: pytest.MonkeyP
 
 
 def test_destroy_reports_stderr_without_the_none_cipher_warning(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The ssh banner does not ride along into a failed destroy's message."""
+    """The ssh banner does not reach a failed destroy's message."""
     _fails_with(monkeypatch, b"WARNING: ENABLED NONE CIPHERcould not find any snapshots to destroy")
 
     with pytest.raises(ZFSReplicateError) as raised:

--- a/zfs_test/replicate_test/snapshot_test/destroy_test.py
+++ b/zfs_test/replicate_test/snapshot_test/destroy_test.py
@@ -1,0 +1,48 @@
+"""zfs.replicate.snapshot.destroy tests."""
+
+import subprocess
+
+import pytest
+
+from zfs.replicate import process
+from zfs.replicate.command import Command
+from zfs.replicate.error import ZFSReplicateError
+from zfs.replicate.filesystem.type import filesystem
+
+# zfs.replicate.snapshot re-exports destroy, so the package attribute is the function,
+# not the module -- import the function rather than aliasing the module as sut.
+from zfs.replicate.snapshot.destroy import destroy
+from zfs.replicate.snapshot.type import Snapshot
+
+SSH = Command.with_empty_env("ssh", "host")
+SNAPSHOT = Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
+
+
+def _fails_with(monkeypatch: pytest.MonkeyPatch, error: bytes) -> None:
+    def fake_run(command: Command, **_kwargs: object) -> "subprocess.CompletedProcess[bytes]":
+        return subprocess.CompletedProcess(command.argv, 1, b"", error)
+
+    monkeypatch.setattr(process, "run", fake_run)
+
+
+def test_destroy_reports_stderr_without_line_endings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed destroy names the reason without the shell's trailing line ending."""
+    _fails_with(monkeypatch, b"could not find any snapshots to destroy\r\n")
+
+    with pytest.raises(ZFSReplicateError) as raised:
+        destroy(SNAPSHOT, SSH)
+
+    assert "could not find any snapshots to destroy" in raised.value.message
+    assert "\\r" not in raised.value.message
+    assert "\\n" not in raised.value.message
+
+
+def test_destroy_reports_stderr_without_the_none_cipher_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ssh banner does not ride along into a failed destroy's message."""
+    _fails_with(monkeypatch, b"WARNING: ENABLED NONE CIPHERcould not find any snapshots to destroy")
+
+    with pytest.raises(ZFSReplicateError) as raised:
+        destroy(SNAPSHOT, SSH)
+
+    assert "could not find any snapshots to destroy" in raised.value.message
+    assert "NONE CIPHER" not in raised.value.message

--- a/zfs_test/replicate_test/stderr_test.py
+++ b/zfs_test/replicate_test/stderr_test.py
@@ -1,0 +1,23 @@
+"""zfs.replicate.stderr tests."""
+
+import zfs.replicate.stderr as sut
+
+
+def test_clean_keeps_a_plain_message_intact() -> None:
+    """Stderr carrying neither kind of noise survives unchanged."""
+    assert sut.clean(b"cannot destroy 'pool/data': dataset is busy") == b"cannot destroy 'pool/data': dataset is busy"
+
+
+def test_clean_drops_trailing_line_endings() -> None:
+    """The line ending a shell appends does not reach the error message."""
+    assert sut.clean(b"cannot open 'pool/data'\r\n") == b"cannot open 'pool/data'"
+
+
+def test_clean_drops_the_none_cipher_warning() -> None:
+    """The banner an unencrypted ssh session prints is not an error."""
+    assert sut.clean(b"WARNING: ENABLED NONE CIPHER\r\n") == b""
+
+
+def test_clean_keeps_a_message_the_none_cipher_warning_precedes() -> None:
+    """Removing the banner leaves the real failure behind it readable."""
+    assert sut.clean(b"WARNING: ENABLED NONE CIPHERcannot open 'pool/data'\n") == b"cannot open 'pool/data'"

--- a/zfs_test/replicate_test/stderr_test.py
+++ b/zfs_test/replicate_test/stderr_test.py
@@ -4,7 +4,7 @@ import zfs.replicate.stderr as sut
 
 
 def test_clean_keeps_a_plain_message_intact() -> None:
-    """Stderr carrying neither kind of noise survives unchanged."""
+    """Stderr carrying no noise survives unchanged."""
     assert sut.clean(b"cannot destroy 'pool/data': dataset is busy") == b"cannot destroy 'pool/data': dataset is busy"
 
 
@@ -19,5 +19,5 @@ def test_clean_drops_the_none_cipher_warning() -> None:
 
 
 def test_clean_keeps_a_message_the_none_cipher_warning_precedes() -> None:
-    """Removing the banner leaves the real failure behind it readable."""
+    """The failure reported after the banner survives its removal."""
     assert sut.clean(b"WARNING: ENABLED NONE CIPHERcannot open 'pool/data'\n") == b"cannot open 'pool/data'"


### PR DESCRIPTION
## Summary

Closes #479. The strip/replace that trims line endings and the none-cipher banner off a command's stderr was copied verbatim into `filesystem.create`, `filesystem.list`, and `snapshot.list`, and was absent from `filesystem.destroy` and `snapshot.destroy`. Four commits:

1. `refactor:` gives the expression one home in `zfs.replicate.stderr`, moved byte for byte.
2. `fix:` applies it at the two destroys, which until now dropped raw `result.stderr` into the raised message, so a destroy failure reported the trailing line ending and, on an unencrypted ssh session, the banner alongside the actual reason.
3. `refactor:` applies two entries from Fowler's catalogue. **Slide Statements** moves `clean(result.stderr)` inside the `returncode` guard at all five sites: every caller reads the cleaned bytes only when raising, so the success path was paying for a strip and a replace it discarded, and the temp outlived the single branch that uses it. **Rename Variable** makes `clean`'s parameter `stderr` rather than `error`, the signature #479 specifies; the argument is raw captured output and only becomes an error message once a caller interpolates it.
4. `docs:` trims the prose this change added, described below.

The helper lives in its own module rather than beside `run()` in `process.py`. The none-cipher banner is ssh-specific knowledge, and `process.py` exists to hold the shell-free exec guarantee. #479 left this home as an open call.

`pytest` (77 passed) and `pre-commit run --all-files` are green. Vale does not read docstrings, so the prose pass in commit 4 was a manual audit rather than a tool run.

## Gotchas

The expression moved byte for byte, and it carries two ordering bugs worth knowing before you read it as correct. `.strip(b"\n").strip(b"\r")` leaves a leading `\n` on `b"\r\nfoo\r\n"`, and the `.replace` runs after the strip, so a banner on its own line leaves `b"\r\nreal error"` behind. There is a third: a single-pass `replace` can synthesize a fresh occurrence, so `clean` has no "output never contains the banner" invariant to property-test, which is why its tests are fixed cases rather than Hypothesis. Fixing any of these is a behavior change, so it stays out of a dedupe change; #663 tracks them.

The two destroy tests import the function rather than aliasing the module. `zfs.replicate.filesystem` and `zfs.replicate.snapshot` re-export `destroy`, so binding the module instead would reach the function and fail on attribute access. Nothing in the test files marks this, because the imports as written are ordinary and a reader who never attempts the alias has nothing to reconcile.

Three further catalogue entries were considered and left alone, so review does not have to wonder whether they were missed. **Extract Function** on the `run` → check → raise envelope is what #479 rules out in its "Out of scope / decided" section. **Replace Magic Literal** on `b"successfully created, but not mounted"` in `filesystem.create` would follow the `_MOUNTPOINT_FAILURE` precedent in `snapshot.send`, but mount status is a different concern from stderr cleanup and belongs in its own change. **Extract Function** on the identical `_fails_with` helper in the two destroy test files sits at two copies, under the rule of three.

`snapshot.send` also reports raw stderr, at `zfs/replicate/snapshot/send.py:94`. #479 enumerates five sites and does not include it, so this change leaves it alone.
