### PR TITLE
test: group tests into per-symbol classes with fixture injection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
           - click-log
           - hypothesis
           - pytest
+          - pytest-mock
   - repo: https://github.com/jendrikseipp/vulture
     rev: v2.16
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ request, or a one-off `Bash` helper.
   live here: `nixpkgs` packages `zfs-replicate` upstream, so a
   local derivation would be a second definition to keep in sync.
 - **Tests:** `pytest` over `zfs_test/`. The conventions it
-  follows, from the `sut` import alias to when a property test
-  beats a fixed input, live in
+  follows, from the class-per-symbol layout and its fixtures to
+  when a property test beats a fixed input, live in
   [docs/reference/testing.md](docs/reference/testing.md).
 - **Lint, format, and types:** match `ruff` and `mypy` when
   writing code. `pre-commit run --all-files` is the canonical

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -4,9 +4,9 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
 `--doctest-modules --cov=zfs --cov-report=term-missing` (configured in
 [`pyproject.toml`](../../pyproject.toml)); `testpaths` is `zfs_test`.
 
-`pytest-randomly` shuffles the order on every run, so a test that depends on
-one before it fails somewhere. Pass `-p no:randomly` to hold the declared order
-while reproducing such a failure. `pytest-xdist` is installed but stays out of
+`pytest-randomly` shuffles the order on every run, so a test that leans on one
+running before it fails rather than passing by luck. Pass `-p no:randomly` to
+hold the declared order while reproducing such a failure. `pytest-xdist` is installed but stays out of
 `addopts`, since `-n auto` spends more on worker startup than it saves at this
 size; ask for it when a run is slow enough to pay for the workers.
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -4,12 +4,26 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
 `--doctest-modules --cov=zfs --cov-report=term-missing` (configured in
 [`pyproject.toml`](../../pyproject.toml)); `testpaths` is `zfs_test`.
 
+`pytest-randomly` shuffles the order on every run, so a test that depends on
+one before it fails somewhere. Pass `-p no:randomly` to hold the declared order
+while reproducing such a failure. `pytest-xdist` is installed but stays out of
+`addopts`, since `-n auto` spends more on worker startup than it saves at this
+size; ask for it when a run is slow enough to pay for the workers.
+
 ## Layout
 
 - A test module mirrors the module under test, with `_test` appended to every
   path segment, directories and file alike.
 - Each test package directory carries an `__init__.py`. Two older directories
   (`cli_test/`, `task_test/`) predate this and lack one; new directories add it.
+- A module's tests group into one class per exported symbol of the module under
+  test, named for that symbol: `TestOverSsh` covers `over_ssh`, and
+  `TestOptionsToFlags` covers `Options.to_flags`.
+- A private helper's tests live in the class of the public symbol it serves.
+  The parsing helpers behind `snapshot.list` are tested under `TestList`, and
+  the assembly helpers behind `snapshot.send` under `TestSend`, so a module's
+  class list reads as its public surface. The method name says which helper the
+  test reaches for.
 
 ## Imports and assertions
 
@@ -18,6 +32,44 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
   rather than re-exporting its symbols.
 - `assert` statements need no marker. `ruff` ignores `S101` (assert-used)
   under `zfs_test/` through `per-file-ignores`, so test code asserts directly.
+
+## Fixtures
+
+A collaborator the test never asserts on is injected. A value the test asserts
+against is written in the test, so the input and the expectation stay side by
+side. That's why the `ssh` command arrives as the `ssh_command` fixture
+wherever it merely has to exist, and as a literal in
+`replicate_test/command_test.py`, where the wrapping is the subject of the
+test.
+
+A fixture lives in the class that uses it, and moves to
+[`zfs_test/conftest.py`](../../zfs_test/conftest.py) once a third module needs
+it. Setup that varies per test comes back as a function: the fixture closes
+over the injected collaborators and returns a callable the test calls with the
+one input it varies, as `assemble` and `capture_spawns` do in
+`snapshot_test/send_test.py`.
+
+```python
+class TestDestroy:
+    @pytest.fixture
+    def snapshot(self) -> Snapshot:
+        """Name the remote snapshot a destroy targets."""
+        return Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
+
+    def test_reports_stderr_without_line_endings(
+        self,
+        mocker: MockerFixture,
+        ssh_command: Command,
+        snapshot: Snapshot,
+    ) -> None:
+        """A failed destroy names the reason without the shell's trailing line ending."""
+        _fails_with(mocker, b"could not find any snapshots to destroy\r\n")
+
+        with pytest.raises(ZFSReplicateError) as raised:
+            destroy(snapshot, ssh_command)
+
+        assert "could not find any snapshots to destroy" in raised.value.message
+```
 
 ## Property tests
 
@@ -36,6 +88,13 @@ Shared strategies for a package live in
 `zfs_test/replicate_test/<pkg>_test/strategies.py` and are imported by that
 package's tests.
 
+A `@given` test takes no fixtures. A function-scoped fixture resolves once
+while `@given` runs the body many times over fresh examples, which Hypothesis
+reports as a `function_scoped_fixture` health check failure. Generated tests
+therefore take their inputs from strategies alone, and the fixtures in the same
+class serve its example-based tests. No test in the suite suppresses that
+health check.
+
 ```python
 from hypothesis import given
 from hypothesis.strategies import lists
@@ -45,11 +104,14 @@ from zfs.replicate.snapshot.type import Snapshot
 from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
-@given(lists(SNAPSHOTS))  # type: ignore[misc]
-def test_snapshots(snapshots: list[Snapshot]) -> None:
-    """Round-trip the rendered list back through the parser."""
-    output = "\n".join(f"{s.filesystem.name}@{s.name}\t{s.timestamp}" for s in snapshots)
-    assert _snapshots(output.encode()) == snapshots
+class TestList:
+    """``list`` reads ``zfs list`` output back into snapshots."""
+
+    @given(lists(SNAPSHOTS))
+    def test_snapshots(self, snapshots: list[Snapshot]) -> None:
+        """Round-trip the rendered list back through the parser."""
+        output = "\n".join(f"{s.filesystem.name}@{s.name}\t{s.timestamp}" for s in snapshots)
+        assert _snapshots(output.encode()) == snapshots
 ```
 
 ## The process boundary
@@ -62,32 +124,44 @@ run-to-completion. Tests never spawn real `zfs` or `ssh`.
 - Command *builders* (`*/command.py`) construct a `Command` and spawn nothing.
   Their tests assert on `Command.argv` and `Command.render()` directly.
 - Code that *runs* a command patches the boundary. A test replaces
-  `zfs.replicate.process.run` (or `process.open`) with `monkeypatch.setattr`,
+  `zfs.replicate.process.run` (or `process.open`) through the `mocker` fixture,
   returning a fake `subprocess.CompletedProcess` or `Popen`, so no external
   binary runs. Patching `process.open` also covers `process.pipeline`, which
   spawns each of its stages through it.
 
 ## Command-line tests
 
-The command line is exercised through `click.testing.CliRunner`. The
-collaborators a command dispatches to—`snapshot.list`, `task.execute`, and the
-like—are patched with `monkeypatch.setattr`; assertions read `result.exit_code`,
-`result.output`, or the arguments the fakes captured.
+The command line is exercised through `click.testing.CliRunner`. A fixture
+patches the collaborators a command dispatches to, such as `snapshot.list` and
+`task.execute`, and hands the test the stub it asserts against. Assertions read
+`result.exit_code`, `result.output`, or the arguments a stub recorded.
 
 ```python
 import zfs.replicate.cli.main as sut
 from click.testing import CliRunner
 
+# Every invocation needs a destination and a key file; only the flags under test vary.
+CONNECTION = ["-l", "alunduil", "-i", "pyproject.toml", "example.com", "bogus", "bogus"]
 
-def test_set_rejects_malformed_property() -> None:
-    """`--receive-set` without an equals sign is rejected before execution."""
-    result = CliRunner().invoke(
-        sut.main,
-        ["--receive-set", "readonly", "-l", "alunduil", "-i", "pyproject.toml",
-         "example.com", "bogus", "bogus"],
-    )
-    assert result.exit_code != 0
-    assert "KEY=VALUE" in result.output
+
+class TestMain:
+    """``main`` parses the command line and hands the run to ``task.execute``."""
+
+    @pytest.fixture
+    def invoke(self) -> Callable[..., Result]:
+        """Invoke the command line with the connection arguments every run needs."""
+
+        def _invoke(*options: str) -> Result:
+            return CliRunner().invoke(sut.main, [*options, *CONNECTION])
+
+        return _invoke
+
+    def test_set_rejects_malformed_property(self, invoke: Callable[..., Result]) -> None:
+        """`--receive-set` without an equals sign is rejected before execution."""
+        result = invoke("--receive-set", "readonly")
+
+        assert result.exit_code != 0
+        assert "KEY=VALUE" in result.output
 ```
 
 ## Regression tests

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -4,11 +4,13 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
 `--doctest-modules --cov=zfs --cov-report=term-missing` (configured in
 [`pyproject.toml`](../../pyproject.toml)); `testpaths` is `zfs_test`.
 
-`pytest-randomly` shuffles the order on every run, so a test that leans on one
-running before it fails rather than passing by luck. Pass `-p no:randomly` to
-hold the declared order while reproducing such a failure. `pytest-xdist` is installed but stays out of
-`addopts`, since `-n auto` spends more on worker startup than it saves at this
-size; ask for it when a run is slow enough to pay for the workers.
+`pytest-randomly` shuffles the order on every run, so a test that depends on
+an earlier one fails instead of passing by luck. Pass `-p no:randomly` to hold
+the declared order while reproducing such a failure.
+
+`pytest-xdist` stays out of `addopts`: at this size, `-n auto` spends more on
+worker startup than it saves. Pass it when a run grows slow enough to pay for
+the workers.
 
 ## Layout
 
@@ -16,14 +18,16 @@ size; ask for it when a run is slow enough to pay for the workers.
   path segment, directories and file alike.
 - Each test package directory carries an `__init__.py`. Two older directories
   (`cli_test/`, `task_test/`) predate this and lack one; new directories add it.
-- A module's tests group into one class per exported symbol of the module under
-  test, named for that symbol: `TestOverSsh` covers `over_ssh`, and
-  `TestOptionsToFlags` covers `Options.to_flags`.
-- A private helper's tests live in the class of the public symbol it serves.
-  The parsing helpers behind `snapshot.list` are tested under `TestList`, and
-  the assembly helpers behind `snapshot.send` under `TestSend`, so a module's
-  class list reads as its public surface. The method name says which helper the
-  test reaches for.
+- A module's tests group into one class per exported symbol, named for it:
+  `TestOverSsh` covers `over_ssh`, `TestOptionsToFlags` covers
+  `Options.to_flags`.
+- A private helper's tests live in the class of the public symbol it serves, so
+  a module's class list reads as its public surface. `snapshot.list`'s parsing
+  helpers are tested under `TestList`, and `snapshot.send`'s assembly helpers
+  under `TestSend`. The method name says which helper a test reaches for.
+- A class docstring says what its tests hold the symbol to, not what the symbol
+  does. The symbol's own docstring covers that, and a paraphrase here drifts
+  from it.
 
 ## Imports and assertions
 
@@ -35,23 +39,20 @@ size; ask for it when a run is slow enough to pay for the workers.
 
 ## Fixtures
 
-A collaborator the test never asserts on is injected. A value the test asserts
-against is written in the test, so the input and the expectation stay side by
-side. That's why the `ssh` command arrives as the `ssh_command` fixture
-wherever it merely has to exist, and as a literal in
-`replicate_test/command_test.py`, where the wrapping is the subject of the
-test.
+Inject a collaborator the test never asserts on. Write a value the test
+asserts against into the test itself, so the input and the expectation stay
+side by side. The `ssh` command shows both: it arrives as the `ssh_command`
+fixture wherever it merely has to exist, and as a literal in
+`replicate_test/command_test.py`, where the tests check how it gets wrapped.
 
 A fixture lives in the class that uses it, and moves to
 [`zfs_test/conftest.py`](../../zfs_test/conftest.py) once a second module needs
-the same setup. Both fixtures there stand at the remote command boundary:
-`ssh_command` builds the invocation a remote command rides on, and `fails_with`
-fails the next run at that boundary with the `stderr` it's given.
+the same setup.
 
 Setup that varies per test comes back as a function. The fixture closes over
-the injected collaborators and returns a callable the test calls with the one
-input it varies, as `fails_with` does here and as `assemble` and
-`capture_spawns` do in `snapshot_test/send_test.py`.
+its collaborators and returns a callable, which the test calls with the one
+input it varies. `fails_with` below does this, as do `assemble` and
+`capture_spawns` in `snapshot_test/send_test.py`.
 
 ```python
 class TestDestroy:
@@ -93,11 +94,10 @@ Shared strategies for a package live in
 package's tests.
 
 A `@given` test takes no fixtures. A function-scoped fixture resolves once
-while `@given` runs the body many times over fresh examples, which Hypothesis
-reports as a `function_scoped_fixture` health check failure. Generated tests
-therefore take their inputs from strategies alone, and the fixtures in the same
-class serve its example-based tests. No test in the suite suppresses that
-health check.
+while `@given` runs the body many times over fresh examples, and Hypothesis
+reports that as a `function_scoped_fixture` health check failure. Generated
+tests take their inputs from strategies alone, and the fixtures in the same
+class serve its example-based tests.
 
 ```python
 from hypothesis import given
@@ -137,8 +137,9 @@ run-to-completion. Tests never spawn real `zfs` or `ssh`.
 
 The command line is exercised through `click.testing.CliRunner`. A fixture
 patches the collaborators a command dispatches to, such as `snapshot.list` and
-`task.execute`, and hands the test the stub it asserts against. Assertions read
-`result.exit_code`, `result.output`, or the arguments a stub recorded.
+`task.execute`, and hands back the stub the test asserts against. Assertions
+read `result.exit_code`, `result.output`, or the arguments that stub
+recorded.
 
 ```python
 import zfs.replicate.cli.main as sut

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -43,11 +43,15 @@ wherever it merely has to exist, and as a literal in
 test.
 
 A fixture lives in the class that uses it, and moves to
-[`zfs_test/conftest.py`](../../zfs_test/conftest.py) once a third module needs
-it. Setup that varies per test comes back as a function: the fixture closes
-over the injected collaborators and returns a callable the test calls with the
-one input it varies, as `assemble` and `capture_spawns` do in
-`snapshot_test/send_test.py`.
+[`zfs_test/conftest.py`](../../zfs_test/conftest.py) once a second module needs
+the same setup. Both fixtures there stand at the remote command boundary:
+`ssh_command` builds the invocation a remote command rides on, and `fails_with`
+fails the next run at that boundary with the `stderr` it's given.
+
+Setup that varies per test comes back as a function. The fixture closes over
+the injected collaborators and returns a callable the test calls with the one
+input it varies, as `fails_with` does here and as `assemble` and
+`capture_spawns` do in `snapshot_test/send_test.py`.
 
 ```python
 class TestDestroy:
@@ -58,12 +62,12 @@ class TestDestroy:
 
     def test_reports_stderr_without_line_endings(
         self,
-        mocker: MockerFixture,
+        fails_with: Callable[[bytes], None],
         ssh_command: Command,
         snapshot: Snapshot,
     ) -> None:
         """A failed destroy names the reason without the shell's trailing line ending."""
-        _fails_with(mocker, b"could not find any snapshots to destroy\r\n")
+        fails_with(b"could not find any snapshots to destroy\r\n")
 
         with pytest.raises(ZFSReplicateError) as raised:
             destroy(snapshot, ssh_command)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -4,13 +4,8 @@ The conventions the `zfs_test/` suite follows. Tests run under `pytest` with
 `--doctest-modules --cov=zfs --cov-report=term-missing` (configured in
 [`pyproject.toml`](../../pyproject.toml)); `testpaths` is `zfs_test`.
 
-`pytest-randomly` shuffles the order on every run, so a test that depends on
-an earlier one fails instead of passing by luck. Pass `-p no:randomly` to hold
-the declared order while reproducing such a failure.
-
-`pytest-xdist` stays out of `addopts`: at this size, `-n auto` spends more on
-worker startup than it saves. Pass it when a run grows slow enough to pay for
-the workers.
+Test order is randomized, so pass `-p no:randomly` to reproduce a failure that
+only appears in some runs.
 
 ## Layout
 
@@ -18,9 +13,7 @@ the workers.
   path segment, directories and file alike.
 - Each test package directory carries an `__init__.py`. Two older directories
   (`cli_test/`, `task_test/`) predate this and lack one; new directories add it.
-- A module's tests group into one class per exported symbol, named for it:
-  `TestOverSsh` covers `over_ssh`, `TestOptionsToFlags` covers
-  `Options.to_flags`.
+- A module's tests group into one class per exported symbol, named for it.
 - A private helper's tests live in the class of the public symbol it serves, so
   a module's class list reads as its public surface. `snapshot.list`'s parsing
   helpers are tested under `TestList`, and `snapshot.send`'s assembly helpers
@@ -49,32 +42,9 @@ A fixture lives in the class that uses it, and moves to
 [`zfs_test/conftest.py`](../../zfs_test/conftest.py) once a second module needs
 the same setup.
 
-Setup that varies per test comes back as a function. The fixture closes over
-its collaborators and returns a callable, which the test calls with the one
-input it varies. `fails_with` below does this, as do `assemble` and
-`capture_spawns` in `snapshot_test/send_test.py`.
-
-```python
-class TestDestroy:
-    @pytest.fixture
-    def snapshot(self) -> Snapshot:
-        """Name the remote snapshot a destroy targets."""
-        return Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
-
-    def test_reports_stderr_without_line_endings(
-        self,
-        fails_with: Callable[[bytes], None],
-        ssh_command: Command,
-        snapshot: Snapshot,
-    ) -> None:
-        """A failed destroy names the reason without the shell's trailing line ending."""
-        fails_with(b"could not find any snapshots to destroy\r\n")
-
-        with pytest.raises(ZFSReplicateError) as raised:
-            destroy(snapshot, ssh_command)
-
-        assert "could not find any snapshots to destroy" in raised.value.message
-```
+Setup that varies per test comes back as a function: the fixture closes over
+its collaborators and returns a callable, as `fails_with`, `assemble`, and
+`capture_spawns` do.
 
 ## Property tests
 
@@ -93,11 +63,8 @@ Shared strategies for a package live in
 `zfs_test/replicate_test/<pkg>_test/strategies.py` and are imported by that
 package's tests.
 
-A `@given` test takes no fixtures. A function-scoped fixture resolves once
-while `@given` runs the body many times over fresh examples, and Hypothesis
-reports that as a `function_scoped_fixture` health check failure. Generated
-tests take their inputs from strategies alone, and the fixtures in the same
-class serve its example-based tests.
+A `@given` test takes no fixtures; the fixtures in its class serve the
+example-based tests beside it.
 
 ```python
 from hypothesis import given
@@ -109,7 +76,7 @@ from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
 class TestList:
-    """``list`` reads ``zfs list`` output back into snapshots."""
+    """Rendered ``zfs list`` output parses back to the snapshots it came from."""
 
     @given(lists(SNAPSHOTS))
     def test_snapshots(self, snapshots: list[Snapshot]) -> None:
@@ -138,36 +105,7 @@ run-to-completion. Tests never spawn real `zfs` or `ssh`.
 The command line is exercised through `click.testing.CliRunner`. A fixture
 patches the collaborators a command dispatches to, such as `snapshot.list` and
 `task.execute`, and hands back the stub the test asserts against. Assertions
-read `result.exit_code`, `result.output`, or the arguments that stub
-recorded.
-
-```python
-import zfs.replicate.cli.main as sut
-from click.testing import CliRunner
-
-# Every invocation needs a destination and a key file; only the flags under test vary.
-CONNECTION = ["-l", "alunduil", "-i", "pyproject.toml", "example.com", "bogus", "bogus"]
-
-
-class TestMain:
-    """``main`` parses the command line and hands the run to ``task.execute``."""
-
-    @pytest.fixture
-    def invoke(self) -> Callable[..., Result]:
-        """Invoke the command line with the connection arguments every run needs."""
-
-        def _invoke(*options: str) -> Result:
-            return CliRunner().invoke(sut.main, [*options, *CONNECTION])
-
-        return _invoke
-
-    def test_set_rejects_malformed_property(self, invoke: Callable[..., Result]) -> None:
-        """`--receive-set` without an equals sign is rejected before execution."""
-        result = invoke("--receive-set", "readonly")
-
-        assert result.exit_code != 0
-        assert "KEY=VALUE" in result.output
-```
+read `result.exit_code`, `result.output`, or the arguments that stub recorded.
 
 ## Regression tests
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -426,6 +426,21 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "hypothesis"
 version = "6.165.10"
 description = "The property-based testing library for Python"
@@ -689,6 +704,60 @@ pytest = ">=7"
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.9"
+groups = ["test"]
+files = [
+    {file = "pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d"},
+    {file = "pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+description = "Pytest plugin to randomly order tests and control random.seed."
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9"},
+    {file = "pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f"},
+]
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["test"]
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 description = "Python HTTP for Humans."
@@ -863,4 +932,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "40c32929dc43cb2209f21b86782760d373d33ee97e8212187d09c1f8d6340cec"
+content-hash = "d4bd5a15c4f4fdd4acf1d79e2ef82685d75abeaa6899515eb4ab2bb06420de17"

--- a/poetry.lock
+++ b/poetry.lock
@@ -426,21 +426,6 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "execnet"
-version = "2.1.2"
-description = "execnet: rapid multi-Python deployment"
-optional = false
-python-versions = ">=3.8"
-groups = ["test"]
-files = [
-    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
-    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
-]
-
-[package.extras]
-testing = ["hatch", "pre-commit", "pytest", "tox"]
-
-[[package]]
 name = "hypothesis"
 version = "6.165.10"
 description = "The property-based testing library for Python"
@@ -893,27 +878,6 @@ files = [
 pytest = "*"
 
 [[package]]
-name = "pytest-xdist"
-version = "3.8.0"
-description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
-optional = false
-python-versions = ">=3.9"
-groups = ["test"]
-files = [
-    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
-    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
-]
-
-[package.dependencies]
-execnet = ">=2.1"
-pytest = ">=7.0.0"
-
-[package.extras]
-psutil = ["psutil (>=3.0)"]
-setproctitle = ["setproctitle"]
-testing = ["filelock"]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -1361,4 +1325,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "2b6e70fac24e9c858768e1ec728305075fab6adadad40909bca972d073655b74"
+content-hash = "797a3fa4ccdbc4f681e3118640368fb964298fbd34e46604a216a8e372ccc0e1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ zfs-replicate = "zfs.replicate.cli.main:main"
 repository = "https://github.com/alunduil/zfs-replicate"
 
 [tool.fawltydeps]
-ignore_unused = ["coveralls", "pytest-cov", "vale"]
+ignore_unused = ["coveralls", "pytest-cov", "pytest-randomly", "pytest-xdist", "vale"]
 
 [tool.mypy]
 strict = true
@@ -58,6 +58,9 @@ hypothesis = "6.165.10"
 # anything older resolves into the advisory range and fails dependency review.
 pytest = "==9.1.1"
 pytest-cov = "==7.1.0"
+pytest-mock = "==3.15.1"
+pytest-randomly = "==4.1.0"
+pytest-xdist = "==3.8.0"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --cov=zfs --cov-report=term-missing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ zfs-replicate = "zfs.replicate.cli.main:main"
 repository = "https://github.com/alunduil/zfs-replicate"
 
 [tool.fawltydeps]
-ignore_unused = ["coveralls", "mutmut", "pytest-cov", "pytest-randomly", "pytest-xdist", "vale"]
+ignore_unused = ["coveralls", "mutmut", "pytest-cov", "pytest-randomly", "vale"]
 
 [tool.mutmut]
 # mutmut runs pytest from a copy of the tree under mutants/, so testpaths only
@@ -75,7 +75,6 @@ pytest = "==9.1.1"
 pytest-cov = "==7.1.0"
 pytest-mock = "==3.15.1"
 pytest-randomly = "==4.1.0"
-pytest-xdist = "==3.8.0"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --cov=zfs --cov-report=term-missing"

--- a/zfs_test/conftest.py
+++ b/zfs_test/conftest.py
@@ -1,7 +1,12 @@
 """Fixtures shared across the suite."""
 
-import pytest
+import subprocess
+from typing import Callable
 
+import pytest
+from pytest_mock import MockerFixture
+
+from zfs.replicate import process
 from zfs.replicate.command import Command
 
 
@@ -9,3 +14,13 @@ from zfs.replicate.command import Command
 def ssh_command() -> Command:
     """Build the ssh invocation that carries a command to the remote host."""
     return Command.with_empty_env("ssh", "host")
+
+
+@pytest.fixture
+def fails_with(mocker: MockerFixture) -> Callable[[bytes], None]:
+    """Fail the run at the process boundary, reporting the given stderr."""
+
+    def _fails_with(error: bytes) -> None:
+        mocker.patch.object(process, "run", return_value=subprocess.CompletedProcess([], 1, b"", error))
+
+    return _fails_with

--- a/zfs_test/conftest.py
+++ b/zfs_test/conftest.py
@@ -18,7 +18,7 @@ def ssh_command() -> Command:
 
 @pytest.fixture
 def fails_with(mocker: MockerFixture) -> Callable[[bytes], None]:
-    """Fail the run at the process boundary, reporting the given stderr."""
+    """Fail the next run at the process boundary with the given stderr."""
 
     def _fails_with(error: bytes) -> None:
         mocker.patch.object(process, "run", return_value=subprocess.CompletedProcess([], 1, b"", error))

--- a/zfs_test/conftest.py
+++ b/zfs_test/conftest.py
@@ -1,0 +1,11 @@
+"""Fixtures shared across the suite."""
+
+import pytest
+
+from zfs.replicate.command import Command
+
+
+@pytest.fixture
+def ssh_command() -> Command:
+    """Build the ssh invocation that carries a command to the remote host."""
+    return Command.with_empty_env("ssh", "host")

--- a/zfs_test/replicate_test/cli_test/log_test.py
+++ b/zfs_test/replicate_test/cli_test/log_test.py
@@ -16,11 +16,7 @@ def _record(level: int, message: str) -> logging.LogRecord:
 
 
 class TestConfigure:
-    """``configure`` installs the formatter that presents operational output.
-
-    That formatter, ``_Formatter``, decides the presentation and is exercised
-    here without routing a whole logging stack through it.
-    """
+    """The installed formatter presents differently off a terminal than on one."""
 
     def test_formatter_prefixes_priority_off_tty(self, mocker: MockerFixture) -> None:
         """Off a terminal, each line carries its sd-daemon priority for journald."""

--- a/zfs_test/replicate_test/cli_test/log_test.py
+++ b/zfs_test/replicate_test/cli_test/log_test.py
@@ -2,7 +2,7 @@
 
 import logging
 
-import pytest
+from pytest_mock import MockerFixture
 
 import zfs.replicate.cli.log as sut
 
@@ -15,19 +15,25 @@ def _record(level: int, message: str) -> logging.LogRecord:
     return logging.LogRecord("zfs.replicate", level, __file__, 0, message, None, None)
 
 
-def test_formatter_prefixes_priority_off_tty(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Off a terminal, each line carries its sd-daemon priority for journald."""
-    monkeypatch.setattr(sut, "_stderr_is_tty", lambda: False)
+class TestConfigure:
+    """``configure`` installs the formatter that presents operational output.
 
-    assert Formatter().format(_record(logging.ERROR, "boom")) == "<3>boom"
-    assert Formatter().format(_record(logging.INFO, "a\nb")) == "<6>a\n<6>b"
+    That formatter, ``_Formatter``, decides the presentation and is exercised
+    here without routing a whole logging stack through it.
+    """
 
+    def test_formatter_prefixes_priority_off_tty(self, mocker: MockerFixture) -> None:
+        """Off a terminal, each line carries its sd-daemon priority for journald."""
+        mocker.patch.object(sut, "_stderr_is_tty", return_value=False)
 
-def test_formatter_colors_on_tty(monkeypatch: pytest.MonkeyPatch) -> None:
-    """On a terminal, click-log's colored ``level:`` presentation is kept."""
-    monkeypatch.setattr(sut, "_stderr_is_tty", lambda: True)
+        assert Formatter().format(_record(logging.ERROR, "boom")) == "<3>boom"
+        assert Formatter().format(_record(logging.INFO, "a\nb")) == "<6>a\n<6>b"
 
-    formatted = Formatter().format(_record(logging.ERROR, "boom"))
+    def test_formatter_colors_on_tty(self, mocker: MockerFixture) -> None:
+        """On a terminal, click-log's colored ``level:`` presentation is kept."""
+        mocker.patch.object(sut, "_stderr_is_tty", return_value=True)
 
-    assert not formatted.startswith("<")
-    assert "error: " in formatted
+        formatted = Formatter().format(_record(logging.ERROR, "boom"))
+
+        assert not formatted.startswith("<")
+        assert "error: " in formatted

--- a/zfs_test/replicate_test/cli_test/main_test.py
+++ b/zfs_test/replicate_test/cli_test/main_test.py
@@ -9,12 +9,12 @@ from pytest_mock import MockerFixture, MockType
 import zfs.replicate.cli.main as sut
 from zfs.replicate import receive, send
 
-# Every invocation needs a destination and a key file; only the flags under test vary.
+# Every invocation needs a destination and a key file.
 CONNECTION = ["-l", "alunduil", "-i", "pyproject.toml", "example.com", "bogus", "bogus"]
 
 
 class TestMain:
-    """``main`` parses the command line and hands the run to ``task.execute``."""
+    """Parsed options reach ``task.execute`` intact, and bad ones stop the run."""
 
     @pytest.fixture
     def invoke(self) -> Callable[..., Result]:
@@ -27,7 +27,7 @@ class TestMain:
 
     @pytest.fixture
     def execute(self, mocker: MockerFixture) -> MockType:
-        """Stand in for the collaborators a run dispatches to, returning the task.execute stub."""
+        """Stand in for the collaborators a run dispatches to."""
         mocker.patch("zfs.replicate.cli.main.snapshot.list", return_value=[])
         mocker.patch("zfs.replicate.cli.main.filesystem.create")
 

--- a/zfs_test/replicate_test/cli_test/main_test.py
+++ b/zfs_test/replicate_test/cli_test/main_test.py
@@ -1,144 +1,100 @@
 """zfs.replicate.cli.main tests."""
 
-from typing import Any, Dict, List
+from typing import Callable
 
 import pytest
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
+from pytest_mock import MockerFixture, MockType
 
 import zfs.replicate.cli.main as sut
 from zfs.replicate import receive, send
-from zfs.replicate.snapshot.type import Snapshot
+
+# Every invocation needs a destination and a key file; only the flags under test vary.
+CONNECTION = ["-l", "alunduil", "-i", "pyproject.toml", "example.com", "bogus", "bogus"]
 
 
-def test_invokes_without_stacktrace() -> None:
-    """Invoke without stacktrace.
+class TestMain:
+    """``main`` parses the command line and hands the run to ``task.execute``."""
 
-    .. code:: bash
+    @pytest.fixture
+    def invoke(self) -> Callable[..., Result]:
+        """Invoke the command line with the connection arguments every run needs."""
 
-        zfs-replicate -l alunduil -i pyproject.toml example.com bogus bogus
-    """
-    runner = CliRunner()
-    result = runner.invoke(sut.main, ["-l", "alunduil", "-i", "pyproject.toml", "example.com", "bogus", "bogus"])
-    assert isinstance(result.exception, SystemExit) or (
-        isinstance(result.exception, FileNotFoundError) and result.exception.filename == "/usr/bin/env"
-    ), "Expected SystemExit or FileNotFoundError."
+        def _invoke(*options: str) -> Result:
+            return CliRunner().invoke(sut.main, [*options, *CONNECTION])
 
+        return _invoke
 
-def test_send_options_thread_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Send flags reach task.execute as the expected send.Options.
+    @pytest.fixture
+    def execute(self, mocker: MockerFixture) -> MockType:
+        """Stand in for the collaborators a run dispatches to, returning the task.execute stub."""
+        mocker.patch("zfs.replicate.cli.main.snapshot.list", return_value=[])
+        mocker.patch("zfs.replicate.cli.main.filesystem.create")
 
-    .. code:: bash
+        return mocker.patch("zfs.replicate.cli.main.task.execute")
 
-        zfs-replicate --send-no-raw --send-large-block --send-embed --send-compressed --send-props ...
-    """
-    captured: Dict[str, Any] = {}
+    def test_invokes_without_stacktrace(self, invoke: Callable[..., Result]) -> None:
+        """Invoke without stacktrace.
 
-    def fake_list(*_args: Any, **_kwargs: Any) -> List[Snapshot]:
-        return []
+        .. code:: bash
 
-    def fake_create(*_args: Any, **_kwargs: Any) -> None:
-        return None
+            zfs-replicate -l alunduil -i pyproject.toml example.com bogus bogus
+        """
+        result = invoke()
 
-    def fake_execute(*_args: Any, **kwargs: Any) -> None:
-        captured.update(kwargs)
+        assert isinstance(result.exception, SystemExit) or (
+            isinstance(result.exception, FileNotFoundError) and result.exception.filename == "/usr/bin/env"
+        ), "Expected SystemExit or FileNotFoundError."
 
-    monkeypatch.setattr("zfs.replicate.cli.main.snapshot.list", fake_list)
-    monkeypatch.setattr("zfs.replicate.cli.main.filesystem.create", fake_create)
-    monkeypatch.setattr("zfs.replicate.cli.main.task.execute", fake_execute)
+    def test_send_options_thread_to_execute(self, invoke: Callable[..., Result], execute: MockType) -> None:
+        """Send flags reach task.execute as the expected send.Options.
 
-    runner = CliRunner()
-    result = runner.invoke(
-        sut.main,
-        [
+        .. code:: bash
+
+            zfs-replicate --send-no-raw --send-large-block --send-embed --send-compressed --send-props ...
+        """
+        result = invoke(
             "--send-no-raw",
             "--send-large-block",
             "--send-embed",
             "--send-compressed",
             "--send-props",
-            "-l",
-            "alunduil",
-            "-i",
-            "pyproject.toml",
-            "example.com",
-            "bogus",
-            "bogus",
-        ],
-    )
-    assert result.exit_code == 0, result.output
+        )
+        assert result.exit_code == 0, result.output
 
-    assert captured.get("send_options") == send.Options(
-        large_block=True, raw=False, embed=True, compressed=True, props=True
-    )
+        assert execute.call_args.kwargs["send_options"] == send.Options(
+            large_block=True, raw=False, embed=True, compressed=True, props=True
+        )
 
+    def test_receive_options_thread_to_execute(self, invoke: Callable[..., Result], execute: MockType) -> None:
+        """Receive flags reach task.execute and shape the receive command.
 
-def test_receive_options_thread_to_execute(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Receive flags reach task.execute and shape the receive command.
+        .. code:: bash
 
-    .. code:: bash
-
-        zfs-replicate --receive-no-force --receive-no-mount --receive-resume-token-capable --receive-set readonly=on ...
-    """
-    captured: Dict[str, Any] = {}
-
-    def fake_list(*_args: Any, **_kwargs: Any) -> List[Snapshot]:
-        return []
-
-    def fake_create(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    def fake_execute(*_args: Any, **kwargs: Any) -> None:
-        captured.update(kwargs)
-
-    monkeypatch.setattr("zfs.replicate.cli.main.snapshot.list", fake_list)
-    monkeypatch.setattr("zfs.replicate.cli.main.filesystem.create", fake_create)
-    monkeypatch.setattr("zfs.replicate.cli.main.task.execute", fake_execute)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        sut.main,
-        [
+            zfs-replicate --receive-no-force --receive-no-mount
+                --receive-resume-token-capable --receive-set readonly=on ...
+        """
+        result = invoke(
             "--receive-no-force",
             "--receive-no-mount",
             "--receive-resume-token-capable",
             "--receive-set",
             "readonly=on",
-            "-l",
-            "alunduil",
-            "-i",
-            "pyproject.toml",
-            "example.com",
-            "bogus",
-            "bogus",
-        ],
-    )
-    assert result.exit_code == 0, result.output
+        )
+        assert result.exit_code == 0, result.output
 
-    assert captured.get("receive_options") == receive.Options(
-        force=False, no_mount=True, resume=True, properties={"readonly": "on"}
-    )
+        assert execute.call_args.kwargs["receive_options"] == receive.Options(
+            force=False, no_mount=True, resume=True, properties={"readonly": "on"}
+        )
 
+    def test_set_rejects_malformed_property(self, invoke: Callable[..., Result]) -> None:
+        """`--receive-set` without an equals sign is rejected before execution.
 
-def test_set_rejects_malformed_property() -> None:
-    """`--receive-set` without an equals sign is rejected before execution.
+        .. code:: bash
 
-    .. code:: bash
+            zfs-replicate --receive-set readonly -l alunduil -i pyproject.toml example.com bogus bogus
+        """
+        result = invoke("--receive-set", "readonly")
 
-        zfs-replicate --receive-set readonly -l alunduil -i pyproject.toml example.com bogus bogus
-    """
-    runner = CliRunner()
-    result = runner.invoke(
-        sut.main,
-        [
-            "--receive-set",
-            "readonly",
-            "-l",
-            "alunduil",
-            "-i",
-            "pyproject.toml",
-            "example.com",
-            "bogus",
-            "bogus",
-        ],
-    )
-    assert result.exit_code != 0
-    assert "KEY=VALUE" in result.output
+        assert result.exit_code != 0
+        assert "KEY=VALUE" in result.output

--- a/zfs_test/replicate_test/command_test.py
+++ b/zfs_test/replicate_test/command_test.py
@@ -3,46 +3,53 @@
 import zfs.replicate.command as sut
 
 
-def test_with_empty_env_prefixes_env() -> None:
-    """The env-empty prefix goes in front of the program and its args."""
-    assert sut.Command.with_empty_env("zfs", "list", "-H").argv == [
-        "/usr/bin/env",
-        "-",
-        "zfs",
-        "list",
-        "-H",
-    ]
+class TestCommandWithEmptyEnv:
+    """``Command.with_empty_env`` builds a command that runs with no environment."""
+
+    def test_prefixes_env(self) -> None:
+        """The env-empty prefix goes in front of the program and its args."""
+        assert sut.Command.with_empty_env("zfs", "list", "-H").argv == [
+            "/usr/bin/env",
+            "-",
+            "zfs",
+            "list",
+            "-H",
+        ]
 
 
-def test_render_quotes_shell_metacharacters() -> None:
-    """Quoting protects any argv token a remote shell would otherwise reparse."""
-    rendered = sut.Command("zfs", ["destroy", "pool/a b; $x"]).render()
+class TestCommandRender:
+    """``Command.render`` writes an argv as a string a remote shell reparses faithfully."""
 
-    assert rendered == "zfs destroy 'pool/a b; $x'"
+    def test_quotes_shell_metacharacters(self) -> None:
+        """Quoting protects any argv token a remote shell would otherwise reparse."""
+        rendered = sut.Command("zfs", ["destroy", "pool/a b; $x"]).render()
 
+        assert rendered == "zfs destroy 'pool/a b; $x'"
 
-def test_render_leaves_safe_tokens_unquoted() -> None:
-    """Safe tokens with no shell-special characters are left unquoted."""
-    assert sut.Command("zfs", ["list", "pool/data"]).render() == "zfs list pool/data"
-
-
-def test_over_ssh_appends_single_quoted_argument() -> None:
-    """Wrapping hands ssh the command as one shell-safe argument."""
-    ssh = sut.Command.with_empty_env("ssh", "host")
-    wrapped = sut.over_ssh(ssh, sut.Command.with_empty_env("zfs", "receive", "pool/a b"))
-
-    assert wrapped.program == "/usr/bin/env"
-    assert wrapped.args[:3] == ["-", "ssh", "host"]
-    assert wrapped.args[-1] == "/usr/bin/env - zfs receive 'pool/a b'"
+    def test_leaves_safe_tokens_unquoted(self) -> None:
+        """Safe tokens with no shell-special characters are left unquoted."""
+        assert sut.Command("zfs", ["list", "pool/data"]).render() == "zfs list pool/data"
 
 
-def test_over_ssh_joins_commands_as_a_pipeline() -> None:
-    """Multiple wrapped commands become a single ' | ' remote pipeline argument."""
-    ssh = sut.Command.with_empty_env("ssh", "host")
-    wrapped = sut.over_ssh(
-        ssh,
-        sut.Command.with_empty_env("lz4", "-d"),
-        sut.Command.with_empty_env("zfs", "receive"),
-    )
+class TestOverSsh:
+    """``over_ssh`` hands commands to ssh as a single remote argument."""
 
-    assert wrapped.args[-1] == "/usr/bin/env - lz4 -d | /usr/bin/env - zfs receive"
+    def test_appends_single_quoted_argument(self) -> None:
+        """Wrapping hands ssh the command as one shell-safe argument."""
+        ssh = sut.Command.with_empty_env("ssh", "host")
+        wrapped = sut.over_ssh(ssh, sut.Command.with_empty_env("zfs", "receive", "pool/a b"))
+
+        assert wrapped.program == "/usr/bin/env"
+        assert wrapped.args[:3] == ["-", "ssh", "host"]
+        assert wrapped.args[-1] == "/usr/bin/env - zfs receive 'pool/a b'"
+
+    def test_joins_commands_as_a_pipeline(self) -> None:
+        """Multiple wrapped commands become a single ' | ' remote pipeline argument."""
+        ssh = sut.Command.with_empty_env("ssh", "host")
+        wrapped = sut.over_ssh(
+            ssh,
+            sut.Command.with_empty_env("lz4", "-d"),
+            sut.Command.with_empty_env("zfs", "receive"),
+        )
+
+        assert wrapped.args[-1] == "/usr/bin/env - lz4 -d | /usr/bin/env - zfs receive"

--- a/zfs_test/replicate_test/command_test.py
+++ b/zfs_test/replicate_test/command_test.py
@@ -4,7 +4,7 @@ import zfs.replicate.command as sut
 
 
 class TestCommandWithEmptyEnv:
-    """``Command.with_empty_env`` builds a command that runs with no environment."""
+    """The env-empty prefix leads every built argv."""
 
     def test_prefixes_env(self) -> None:
         """The env-empty prefix goes in front of the program and its args."""
@@ -18,7 +18,7 @@ class TestCommandWithEmptyEnv:
 
 
 class TestCommandRender:
-    """``Command.render`` writes an argv as a string a remote shell reparses faithfully."""
+    """Rendering quotes the tokens a remote shell would reparse, and only those."""
 
     def test_quotes_shell_metacharacters(self) -> None:
         """Quoting protects any argv token a remote shell would otherwise reparse."""
@@ -32,7 +32,7 @@ class TestCommandRender:
 
 
 class TestOverSsh:
-    """``over_ssh`` hands commands to ssh as a single remote argument."""
+    """The wrapped commands arrive as ssh's single trailing argument."""
 
     def test_appends_single_quoted_argument(self) -> None:
         """Wrapping hands ssh the command as one shell-safe argument."""

--- a/zfs_test/replicate_test/compress_test/command_test.py
+++ b/zfs_test/replicate_test/compress_test/command_test.py
@@ -9,10 +9,7 @@ from zfs.replicate.compress.type import Compression
 class TestCommand:
     """``command`` renders the compressor and decompressor a compression names."""
 
-    def test_total(self) -> None:
+    @pytest.mark.parametrize("compression", list(Compression))
+    def test_total(self, compression: Compression) -> None:
         """Ensure command is a total function."""
-        for compression in Compression:
-            try:
-                command(compression)
-            except ValueError:
-                pytest.fail(f"unhandled case for {compression}")
+        command(compression)

--- a/zfs_test/replicate_test/compress_test/command_test.py
+++ b/zfs_test/replicate_test/compress_test/command_test.py
@@ -6,10 +6,13 @@ from zfs.replicate.compress.command import command
 from zfs.replicate.compress.type import Compression
 
 
-def test_command_total() -> None:
-    """Ensure command is a total function."""
-    for compression in Compression:
-        try:
-            command(compression)
-        except ValueError:
-            pytest.fail(f"unhandled case for {compression}")
+class TestCommand:
+    """``command`` renders the compressor and decompressor a compression names."""
+
+    def test_total(self) -> None:
+        """Ensure command is a total function."""
+        for compression in Compression:
+            try:
+                command(compression)
+            except ValueError:
+                pytest.fail(f"unhandled case for {compression}")

--- a/zfs_test/replicate_test/compress_test/command_test.py
+++ b/zfs_test/replicate_test/compress_test/command_test.py
@@ -7,7 +7,7 @@ from zfs.replicate.compress.type import Compression
 
 
 class TestCommand:
-    """``command`` renders the compressor and decompressor a compression names."""
+    """Every compression maps to a command, so no member falls through."""
 
     @pytest.mark.parametrize("compression", list(Compression))
     def test_total(self, compression: Compression) -> None:

--- a/zfs_test/replicate_test/filesystem_test/destroy_test.py
+++ b/zfs_test/replicate_test/filesystem_test/destroy_test.py
@@ -11,7 +11,7 @@ from zfs.replicate.filesystem.type import FileSystem, filesystem
 
 
 class TestDestroy:
-    """``destroy`` removes a remote filesystem, reporting why a failed removal failed."""
+    """A failed destroy raises with the remote's reason, and nothing else."""
 
     @pytest.fixture
     def dataset(self) -> FileSystem:

--- a/zfs_test/replicate_test/filesystem_test/destroy_test.py
+++ b/zfs_test/replicate_test/filesystem_test/destroy_test.py
@@ -1,19 +1,13 @@
 """zfs.replicate.filesystem.destroy tests."""
 
-import subprocess
+from typing import Callable
 
 import pytest
-from pytest_mock import MockerFixture
 
-from zfs.replicate import process
 from zfs.replicate.command import Command
 from zfs.replicate.error import ZFSReplicateError
 from zfs.replicate.filesystem.destroy import destroy
 from zfs.replicate.filesystem.type import FileSystem, filesystem
-
-
-def _fails_with(mocker: MockerFixture, error: bytes) -> None:
-    mocker.patch.object(process, "run", return_value=subprocess.CompletedProcess([], 1, b"", error))
 
 
 class TestDestroy:
@@ -26,12 +20,12 @@ class TestDestroy:
 
     def test_reports_stderr_without_line_endings(
         self,
-        mocker: MockerFixture,
+        fails_with: Callable[[bytes], None],
         ssh_command: Command,
         dataset: FileSystem,
     ) -> None:
         """A failed destroy names the reason without the shell's trailing line ending."""
-        _fails_with(mocker, b"cannot destroy 'pool/data': dataset is busy\r\n")
+        fails_with(b"cannot destroy 'pool/data': dataset is busy\r\n")
 
         with pytest.raises(ZFSReplicateError) as raised:
             destroy(dataset, ssh_command)
@@ -42,12 +36,12 @@ class TestDestroy:
 
     def test_reports_stderr_without_the_none_cipher_warning(
         self,
-        mocker: MockerFixture,
+        fails_with: Callable[[bytes], None],
         ssh_command: Command,
         dataset: FileSystem,
     ) -> None:
         """The ssh banner does not reach a failed destroy's message."""
-        _fails_with(mocker, b"WARNING: ENABLED NONE CIPHERcannot destroy 'pool/data': dataset is busy")
+        fails_with(b"WARNING: ENABLED NONE CIPHERcannot destroy 'pool/data': dataset is busy")
 
         with pytest.raises(ZFSReplicateError) as raised:
             destroy(dataset, ssh_command)

--- a/zfs_test/replicate_test/filesystem_test/destroy_test.py
+++ b/zfs_test/replicate_test/filesystem_test/destroy_test.py
@@ -3,41 +3,54 @@
 import subprocess
 
 import pytest
+from pytest_mock import MockerFixture
 
 from zfs.replicate import process
 from zfs.replicate.command import Command
 from zfs.replicate.error import ZFSReplicateError
 from zfs.replicate.filesystem.destroy import destroy
-from zfs.replicate.filesystem.type import filesystem
-
-SSH = Command.with_empty_env("ssh", "host")
+from zfs.replicate.filesystem.type import FileSystem, filesystem
 
 
-def _fails_with(monkeypatch: pytest.MonkeyPatch, error: bytes) -> None:
-    def fake_run(command: Command, **_kwargs: object) -> "subprocess.CompletedProcess[bytes]":
-        return subprocess.CompletedProcess(command.argv, 1, b"", error)
-
-    monkeypatch.setattr(process, "run", fake_run)
+def _fails_with(mocker: MockerFixture, error: bytes) -> None:
+    mocker.patch.object(process, "run", return_value=subprocess.CompletedProcess([], 1, b"", error))
 
 
-def test_destroy_reports_stderr_without_line_endings(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A failed destroy names the reason without the shell's trailing line ending."""
-    _fails_with(monkeypatch, b"cannot destroy 'pool/data': dataset is busy\r\n")
+class TestDestroy:
+    """``destroy`` removes a remote filesystem, reporting why a failed removal failed."""
 
-    with pytest.raises(ZFSReplicateError) as raised:
-        destroy(filesystem("pool/data"), SSH)
+    @pytest.fixture
+    def dataset(self) -> FileSystem:
+        """Name the remote filesystem a destroy targets."""
+        return filesystem("pool/data")
 
-    assert "dataset is busy" in raised.value.message
-    assert "\\r" not in raised.value.message
-    assert "\\n" not in raised.value.message
+    def test_reports_stderr_without_line_endings(
+        self,
+        mocker: MockerFixture,
+        ssh_command: Command,
+        dataset: FileSystem,
+    ) -> None:
+        """A failed destroy names the reason without the shell's trailing line ending."""
+        _fails_with(mocker, b"cannot destroy 'pool/data': dataset is busy\r\n")
 
+        with pytest.raises(ZFSReplicateError) as raised:
+            destroy(dataset, ssh_command)
 
-def test_destroy_reports_stderr_without_the_none_cipher_warning(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The ssh banner does not reach a failed destroy's message."""
-    _fails_with(monkeypatch, b"WARNING: ENABLED NONE CIPHERcannot destroy 'pool/data': dataset is busy")
+        assert "dataset is busy" in raised.value.message
+        assert "\\r" not in raised.value.message
+        assert "\\n" not in raised.value.message
 
-    with pytest.raises(ZFSReplicateError) as raised:
-        destroy(filesystem("pool/data"), SSH)
+    def test_reports_stderr_without_the_none_cipher_warning(
+        self,
+        mocker: MockerFixture,
+        ssh_command: Command,
+        dataset: FileSystem,
+    ) -> None:
+        """The ssh banner does not reach a failed destroy's message."""
+        _fails_with(mocker, b"WARNING: ENABLED NONE CIPHERcannot destroy 'pool/data': dataset is busy")
 
-    assert "dataset is busy" in raised.value.message
-    assert "NONE CIPHER" not in raised.value.message
+        with pytest.raises(ZFSReplicateError) as raised:
+            destroy(dataset, ssh_command)
+
+        assert "dataset is busy" in raised.value.message
+        assert "NONE CIPHER" not in raised.value.message

--- a/zfs_test/replicate_test/list_test.py
+++ b/zfs_test/replicate_test/list_test.py
@@ -36,10 +36,6 @@ class TestVenn:
     @given(sets(integers()), sets(integers()))
     def test_subsets(self, lefts: Set[int], rights: Set[int]) -> None:
         """All combinations of venn with subsets."""
-        r_lefts: List[int]
-        r_middles: List[int]
-        r_rights: List[int]
-
         r_lefts, r_middles, r_rights = sut.venn(list(lefts), list(lefts | rights))
 
         assert (set(r_lefts), set(r_middles), set(r_rights)) == (
@@ -61,10 +57,6 @@ class TestVenn:
         """Venn with disjoint."""
         e_lefts = list(filter(lambda x: x % 2 == 0, both))
         e_rights = list(filter(lambda x: x % 2 != 0, both))
-
-        r_lefts: List[int]
-        r_middles: List[int]
-        r_rights: List[int]
 
         r_lefts, r_middles, r_rights = sut.venn(list(e_lefts), list(e_rights))
 

--- a/zfs_test/replicate_test/list_test.py
+++ b/zfs_test/replicate_test/list_test.py
@@ -8,65 +8,68 @@ from hypothesis.strategies import integers, lists, sets
 from zfs.replicate import list as sut
 
 
-@given(lists(integers()))
-def test_inits_length(elements: List[int]) -> None:
-    """len(inits(elements)) == len(elements) + 1."""
-    assert len(sut.inits(elements)) == len(elements) + 1
+class TestInits:
+    """``inits`` enumerates every prefix of a sequence, shortest first."""
+
+    @given(lists(integers()))
+    def test_length(self, elements: List[int]) -> None:
+        """len(inits(elements)) == len(elements) + 1."""
+        assert len(sut.inits(elements)) == len(elements) + 1
+
+    @given(lists(integers(), min_size=2))
+    def test_heads(self, elements: List[int]) -> None:
+        """inits(elements)[:1] == [[], [elements[0]]."""
+        assert sut.inits(elements)[0] == []
+        assert sut.inits(elements)[1] == [elements[0]]
+
+    @given(lists(integers()))
+    def test_monotonic_length(self, elements: List[int]) -> None:
+        """[len(x) for xs in inits(elements)] == range(len(elements) + 1)."""
+        lengths = [len(xs) for xs in sut.inits(elements)]
+
+        assert lengths == list(range(len(elements) + 1))
 
 
-@given(lists(integers(), min_size=2))
-def test_inits_heads(elements: List[int]) -> None:
-    """inits(elements)[:1] == [[], [elements[0]]."""
-    assert sut.inits(elements)[0] == []
-    assert sut.inits(elements)[1] == [elements[0]]
+class TestVenn:
+    """``venn`` splits two sequences into left-only, shared, and right-only parts."""
 
+    @given(sets(integers()), sets(integers()))
+    def test_subsets(self, lefts: Set[int], rights: Set[int]) -> None:
+        """All combinations of venn with subsets."""
+        r_lefts: List[int]
+        r_middles: List[int]
+        r_rights: List[int]
 
-@given(lists(integers()))
-def test_inits_monotonic_length(elements: List[int]) -> None:
-    """[len(x) for xs in inits(elements)] == range(len(elements) + 1)."""
-    lengths = [len(xs) for xs in sut.inits(elements)]
+        r_lefts, r_middles, r_rights = sut.venn(list(lefts), list(lefts | rights))
 
-    assert lengths == list(range(len(elements) + 1))
+        assert (set(r_lefts), set(r_middles), set(r_rights)) == (
+            set(),
+            lefts,
+            rights - lefts,
+        )
 
+        r_lefts, r_middles, r_rights = sut.venn(list(lefts | rights), list(rights))
 
-@given(sets(integers()), sets(integers()))
-def test_venn_subsets(lefts: Set[int], rights: Set[int]) -> None:
-    """All combinations of venn with subsets."""
-    r_lefts: List[int]
-    r_middles: List[int]
-    r_rights: List[int]
+        assert (set(r_lefts), set(r_middles), set(r_rights)) == (
+            lefts - rights,
+            rights,
+            set(),
+        )
 
-    r_lefts, r_middles, r_rights = sut.venn(list(lefts), list(lefts | rights))
+    @given(lists(integers()))
+    def test_disjoint(self, both: List[int]) -> None:
+        """Venn with disjoint."""
+        e_lefts = list(filter(lambda x: x % 2 == 0, both))
+        e_rights = list(filter(lambda x: x % 2 != 0, both))
 
-    assert (set(r_lefts), set(r_middles), set(r_rights)) == (
-        set(),
-        lefts,
-        rights - lefts,
-    )
+        r_lefts: List[int]
+        r_middles: List[int]
+        r_rights: List[int]
 
-    r_lefts, r_middles, r_rights = sut.venn(list(lefts | rights), list(rights))
+        r_lefts, r_middles, r_rights = sut.venn(list(e_lefts), list(e_rights))
 
-    assert (set(r_lefts), set(r_middles), set(r_rights)) == (
-        lefts - rights,
-        rights,
-        set(),
-    )
-
-
-@given(lists(integers()))
-def test_venn_disjoint(both: List[int]) -> None:
-    """Venn with disjoint."""
-    e_lefts = list(filter(lambda x: x % 2 == 0, both))
-    e_rights = list(filter(lambda x: x % 2 != 0, both))
-
-    r_lefts: List[int]
-    r_middles: List[int]
-    r_rights: List[int]
-
-    r_lefts, r_middles, r_rights = sut.venn(list(e_lefts), list(e_rights))
-
-    assert (list(r_lefts), list(r_middles), list(r_rights)) == (
-        e_lefts,
-        [],
-        e_rights,
-    )
+        assert (list(r_lefts), list(r_middles), list(r_rights)) == (
+            e_lefts,
+            [],
+            e_rights,
+        )

--- a/zfs_test/replicate_test/list_test.py
+++ b/zfs_test/replicate_test/list_test.py
@@ -9,7 +9,7 @@ from zfs.replicate import list as sut
 
 
 class TestInits:
-    """``inits`` enumerates every prefix of a sequence, shortest first."""
+    """Every prefix appears once, in increasing length."""
 
     @given(lists(integers()))
     def test_length(self, elements: List[int]) -> None:
@@ -31,7 +31,7 @@ class TestInits:
 
 
 class TestVenn:
-    """``venn`` splits two sequences into left-only, shared, and right-only parts."""
+    """Each element lands in exactly one of the three parts."""
 
     @given(sets(integers()), sets(integers()))
     def test_subsets(self, lefts: Set[int], rights: Set[int]) -> None:

--- a/zfs_test/replicate_test/optional_test.py
+++ b/zfs_test/replicate_test/optional_test.py
@@ -8,33 +8,37 @@ from hypothesis.strategies import integers, lists, none, one_of
 from zfs.replicate import optional
 
 
-def test_value_none() -> None:
-    """optional.value(None) → RuntimeError."""
-    # Use try except due to lack of typing on pytest module.
-    try:
-        optional.value(None)
-    except RuntimeError:
-        pass
-    except:  # noqa: E722
-        raise AssertionError("Expected RuntimeError") from None
+class TestValue:
+    """``value`` unwraps an optional that must be present."""
+
+    def test_none(self) -> None:
+        """optional.value(None) → RuntimeError."""
+        # Use try except due to lack of typing on pytest module.
+        try:
+            optional.value(None)
+        except RuntimeError:
+            pass
+        except:  # noqa: E722
+            raise AssertionError("Expected RuntimeError") from None
+
+    @given(integers())
+    def test_not_none(self, value: int) -> None:
+        """optional.value(value) == value."""
+        assert optional.value(value) == value
 
 
-@given(integers())
-def test_value_not_none(value: int) -> None:
-    """optional.value(value) == value."""
-    assert optional.value(value) == value
+class TestValues:
+    """``values`` keeps the present members of a sequence of optionals."""
 
+    @given(lists(one_of(integers(), none())))
+    def test_drops_every_none(self, elements: List[Optional[int]]) -> None:
+        """No None survives, and a second pass has nothing left to drop."""
+        kept = optional.values(*elements)
 
-@given(lists(one_of(integers(), none())))
-def test_values_drops_every_none(elements: List[Optional[int]]) -> None:
-    """No None survives, and a second pass has nothing left to drop."""
-    kept = optional.values(*elements)
+        assert None not in kept
+        assert optional.values(*kept) == kept
 
-    assert None not in kept
-    assert optional.values(*kept) == kept
-
-
-@given(lists(integers()))
-def test_values_keeps_present_values_in_order(elements: List[int]) -> None:
-    """Nothing is missing, so everything comes back as it went in."""
-    assert optional.values(*elements) == elements
+    @given(lists(integers()))
+    def test_keeps_present_values_in_order(self, elements: List[int]) -> None:
+        """Nothing is missing, so everything comes back as it went in."""
+        assert optional.values(*elements) == elements

--- a/zfs_test/replicate_test/optional_test.py
+++ b/zfs_test/replicate_test/optional_test.py
@@ -2,6 +2,7 @@
 
 from typing import List, Optional
 
+import pytest
 from hypothesis import given
 from hypothesis.strategies import integers, lists, none, one_of
 
@@ -13,13 +14,8 @@ class TestValue:
 
     def test_none(self) -> None:
         """optional.value(None) → RuntimeError."""
-        # Use try except due to lack of typing on pytest module.
-        try:
+        with pytest.raises(RuntimeError):
             optional.value(None)
-        except RuntimeError:
-            pass
-        except:  # noqa: E722
-            raise AssertionError("Expected RuntimeError") from None
 
     @given(integers())
     def test_not_none(self, value: int) -> None:

--- a/zfs_test/replicate_test/optional_test.py
+++ b/zfs_test/replicate_test/optional_test.py
@@ -10,7 +10,7 @@ from zfs.replicate import optional
 
 
 class TestValue:
-    """``value`` unwraps an optional that must be present."""
+    """A present value comes back, and a missing one raises."""
 
     def test_none(self) -> None:
         """optional.value(None) → RuntimeError."""
@@ -24,7 +24,7 @@ class TestValue:
 
 
 class TestValues:
-    """``values`` keeps the present members of a sequence of optionals."""
+    """Nothing missing survives, and everything present keeps its order."""
 
     @given(lists(one_of(integers(), none())))
     def test_drops_every_none(self, elements: List[Optional[int]]) -> None:

--- a/zfs_test/replicate_test/process_test.py
+++ b/zfs_test/replicate_test/process_test.py
@@ -4,37 +4,41 @@ import zfs.replicate.process as sut
 from zfs.replicate.command import Command
 
 
-def test_run_passes_arguments_without_a_shell() -> None:
-    """An argument with shell syntax reaches the program verbatim, unexpanded."""
-    hostile = "$(echo pwned) `id` ; rm -rf"
+class TestRun:
+    """``run`` executes a command to completion and reports its result."""
 
-    result = sut.run(Command("printf", ["%s", hostile]))
+    def test_passes_arguments_without_a_shell(self) -> None:
+        """An argument with shell syntax reaches the program verbatim, unexpanded."""
+        hostile = "$(echo pwned) `id` ; rm -rf"
 
-    assert result.returncode == 0
-    assert result.stdout == hostile.encode()
+        result = sut.run(Command("printf", ["%s", hostile]))
 
+        assert result.returncode == 0
+        assert result.stdout == hostile.encode()
 
-def test_run_reports_nonzero_returncode() -> None:
-    """A failing program surfaces its exit status on the result."""
-    result = sut.run(Command("false", []))
+    def test_reports_nonzero_returncode(self) -> None:
+        """A failing program surfaces its exit status on the result."""
+        result = sut.run(Command("false", []))
 
-    assert result.returncode != 0
-
-
-def test_pipeline_feeds_each_stage_into_the_next() -> None:
-    """A stage's stdout arrives on the next stage's stdin."""
-    proc = sut.pipeline(Command("printf", ["%s", "replicate"]), Command("tr", ["a-z", "A-Z"]))
-
-    output, _ = proc.communicate()
-
-    assert output == b"REPLICATE"
+        assert result.returncode != 0
 
 
-def test_pipeline_captures_both_streams_of_a_lone_stage() -> None:
-    """A lone stage is also the last one, so its streams reach the caller."""
-    proc = sut.pipeline(Command("printf", ["%s", "solo"]))
+class TestPipeline:
+    """``pipeline`` chains each command's output into the next."""
 
-    output, error = proc.communicate()
+    def test_feeds_each_stage_into_the_next(self) -> None:
+        """A stage's stdout arrives on the next stage's stdin."""
+        proc = sut.pipeline(Command("printf", ["%s", "replicate"]), Command("tr", ["a-z", "A-Z"]))
 
-    assert output == b"solo"
-    assert error == b""
+        output, _ = proc.communicate()
+
+        assert output == b"REPLICATE"
+
+    def test_captures_both_streams_of_a_lone_stage(self) -> None:
+        """A lone stage is also the last one, so its streams reach the caller."""
+        proc = sut.pipeline(Command("printf", ["%s", "solo"]))
+
+        output, error = proc.communicate()
+
+        assert output == b"solo"
+        assert error == b""

--- a/zfs_test/replicate_test/process_test.py
+++ b/zfs_test/replicate_test/process_test.py
@@ -5,7 +5,7 @@ from zfs.replicate.command import Command
 
 
 class TestRun:
-    """``run`` executes a command to completion and reports its result."""
+    """Arguments reach the program unexpanded, and a failure keeps its status."""
 
     def test_passes_arguments_without_a_shell(self) -> None:
         """An argument with shell syntax reaches the program verbatim, unexpanded."""
@@ -24,7 +24,7 @@ class TestRun:
 
 
 class TestPipeline:
-    """``pipeline`` chains each command's output into the next."""
+    """Each stage's output feeds the next, and the caller reads the last."""
 
     def test_feeds_each_stage_into_the_next(self) -> None:
         """A stage's stdout arrives on the next stage's stdin."""

--- a/zfs_test/replicate_test/receive_test/command_test.py
+++ b/zfs_test/replicate_test/receive_test/command_test.py
@@ -6,7 +6,7 @@ from zfs.replicate.receive.type import Options
 
 
 class TestCommand:
-    """``command`` renders the remote ``zfs receive`` invocation."""
+    """The rendered argv keeps ``-d`` beside the destination, whatever the flags."""
 
     def test_assembles_receive_invocation(self) -> None:
         """Wrap the flags and destination in a zfs receive argv."""

--- a/zfs_test/replicate_test/receive_test/command_test.py
+++ b/zfs_test/replicate_test/receive_test/command_test.py
@@ -5,38 +5,39 @@ from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.receive.type import Options
 
 
-def test_command_assembles_receive_invocation() -> None:
-    """Wrap the flags and destination in a zfs receive argv."""
-    result = sut.command(filesystem("remote/pool"), Options())
+class TestCommand:
+    """``command`` renders the remote ``zfs receive`` invocation."""
 
-    assert result.argv == [
-        "/usr/bin/env",
-        "-",
-        "zfs",
-        "receive",
-        "-F",
-        "-d",
-        "remote/pool",
-    ]
+    def test_assembles_receive_invocation(self) -> None:
+        """Wrap the flags and destination in a zfs receive argv."""
+        result = sut.command(filesystem("remote/pool"), Options())
 
+        assert result.argv == [
+            "/usr/bin/env",
+            "-",
+            "zfs",
+            "receive",
+            "-F",
+            "-d",
+            "remote/pool",
+        ]
 
-def test_command_without_flags_abuts_destination() -> None:
-    """Keep -d next to the destination even when no option flags render."""
-    result = sut.command(filesystem("remote/pool"), Options(force=False))
+    def test_without_flags_abuts_destination(self) -> None:
+        """Keep -d next to the destination even when no option flags render."""
+        result = sut.command(filesystem("remote/pool"), Options(force=False))
 
-    assert result.argv == [
-        "/usr/bin/env",
-        "-",
-        "zfs",
-        "receive",
-        "-d",
-        "remote/pool",
-    ]
+        assert result.argv == [
+            "/usr/bin/env",
+            "-",
+            "zfs",
+            "receive",
+            "-d",
+            "remote/pool",
+        ]
 
+    def test_keeps_hostile_destination_as_one_token(self) -> None:
+        """A destination with shell metacharacters stays a single argv token."""
+        result = sut.command(filesystem("remote/pool a$b"), Options())
 
-def test_command_keeps_hostile_destination_as_one_token() -> None:
-    """A destination with shell metacharacters stays a single argv token."""
-    result = sut.command(filesystem("remote/pool a$b"), Options())
-
-    assert result.argv[-1] == "remote/pool a$b"
-    assert "'remote/pool a$b'" in result.render()
+        assert result.argv[-1] == "remote/pool a$b"
+        assert "'remote/pool a$b'" in result.render()

--- a/zfs_test/replicate_test/receive_test/type_test.py
+++ b/zfs_test/replicate_test/receive_test/type_test.py
@@ -4,7 +4,7 @@ import zfs.replicate.receive.type as sut
 
 
 class TestOptionsToFlags:
-    """``Options.to_flags`` renders the ``zfs receive`` flags a run asked for."""
+    """Each enabled setting contributes its flag, and nothing else does."""
 
     def test_forces_by_default(self) -> None:
         """Default options render only -F."""

--- a/zfs_test/replicate_test/receive_test/type_test.py
+++ b/zfs_test/replicate_test/receive_test/type_test.py
@@ -3,28 +3,27 @@
 import zfs.replicate.receive.type as sut
 
 
-def test_to_flags_forces_by_default() -> None:
-    """Default options render only -F."""
-    assert sut.Options().to_flags() == ["-F"]
+class TestOptionsToFlags:
+    """``Options.to_flags`` renders the ``zfs receive`` flags a run asked for."""
 
+    def test_forces_by_default(self) -> None:
+        """Default options render only -F."""
+        assert sut.Options().to_flags() == ["-F"]
 
-def test_to_flags_omits_force_when_disabled() -> None:
-    """Disabling force renders no flags."""
-    assert not sut.Options(force=False).to_flags()
+    def test_omits_force_when_disabled(self) -> None:
+        """Disabling force renders no flags."""
+        assert not sut.Options(force=False).to_flags()
 
+    def test_adds_no_mount(self) -> None:
+        """Enabling no_mount renders -u."""
+        assert "-u" in sut.Options(no_mount=True).to_flags()
 
-def test_to_flags_adds_no_mount() -> None:
-    """Enabling no_mount renders -u."""
-    assert "-u" in sut.Options(no_mount=True).to_flags()
+    def test_adds_resume(self) -> None:
+        """Enabling resume renders -s."""
+        assert "-s" in sut.Options(resume=True).to_flags()
 
+    def test_renders_properties(self) -> None:
+        """Each property renders a -o token followed by its KEY=VALUE token."""
+        flags = sut.Options(force=False, properties={"readonly": "on", "canmount": "noauto"}).to_flags()
 
-def test_to_flags_adds_resume() -> None:
-    """Enabling resume renders -s."""
-    assert "-s" in sut.Options(resume=True).to_flags()
-
-
-def test_to_flags_renders_properties() -> None:
-    """Each property renders a -o token followed by its KEY=VALUE token."""
-    flags = sut.Options(force=False, properties={"readonly": "on", "canmount": "noauto"}).to_flags()
-
-    assert flags == ["-o", "readonly=on", "-o", "canmount=noauto"]
+        assert flags == ["-o", "readonly=on", "-o", "canmount=noauto"]

--- a/zfs_test/replicate_test/send_test/type_test.py
+++ b/zfs_test/replicate_test/send_test/type_test.py
@@ -3,31 +3,29 @@
 import zfs.replicate.send.type as sut
 
 
-def test_to_flags_raws_by_default() -> None:
-    """Default options render only -w."""
-    assert sut.Options().to_flags() == ["-w"]
+class TestOptionsToFlags:
+    """``Options.to_flags`` renders the ``zfs send`` flags a run asked for."""
 
+    def test_raws_by_default(self) -> None:
+        """Default options render only -w."""
+        assert sut.Options().to_flags() == ["-w"]
 
-def test_to_flags_omits_raw_when_disabled() -> None:
-    """Disabling raw renders no flags."""
-    assert not sut.Options(raw=False).to_flags()
+    def test_omits_raw_when_disabled(self) -> None:
+        """Disabling raw renders no flags."""
+        assert not sut.Options(raw=False).to_flags()
 
+    def test_adds_large_block(self) -> None:
+        """Enabling large_block renders -L."""
+        assert "-L" in sut.Options(large_block=True).to_flags()
 
-def test_to_flags_adds_large_block() -> None:
-    """Enabling large_block renders -L."""
-    assert "-L" in sut.Options(large_block=True).to_flags()
+    def test_adds_embed(self) -> None:
+        """Enabling embed renders -e."""
+        assert "-e" in sut.Options(embed=True).to_flags()
 
+    def test_adds_compressed(self) -> None:
+        """Enabling compressed renders -c."""
+        assert "-c" in sut.Options(compressed=True).to_flags()
 
-def test_to_flags_adds_embed() -> None:
-    """Enabling embed renders -e."""
-    assert "-e" in sut.Options(embed=True).to_flags()
-
-
-def test_to_flags_adds_compressed() -> None:
-    """Enabling compressed renders -c."""
-    assert "-c" in sut.Options(compressed=True).to_flags()
-
-
-def test_to_flags_adds_props() -> None:
-    """Enabling props renders -p."""
-    assert "-p" in sut.Options(props=True).to_flags()
+    def test_adds_props(self) -> None:
+        """Enabling props renders -p."""
+        assert "-p" in sut.Options(props=True).to_flags()

--- a/zfs_test/replicate_test/send_test/type_test.py
+++ b/zfs_test/replicate_test/send_test/type_test.py
@@ -4,7 +4,7 @@ import zfs.replicate.send.type as sut
 
 
 class TestOptionsToFlags:
-    """``Options.to_flags`` renders the ``zfs send`` flags a run asked for."""
+    """Each enabled setting contributes its flag, and nothing else does."""
 
     def test_raws_by_default(self) -> None:
         """Default options render only -w."""

--- a/zfs_test/replicate_test/snapshot_test/destroy_test.py
+++ b/zfs_test/replicate_test/snapshot_test/destroy_test.py
@@ -1,20 +1,14 @@
 """zfs.replicate.snapshot.destroy tests."""
 
-import subprocess
+from typing import Callable
 
 import pytest
-from pytest_mock import MockerFixture
 
-from zfs.replicate import process
 from zfs.replicate.command import Command
 from zfs.replicate.error import ZFSReplicateError
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.destroy import destroy
 from zfs.replicate.snapshot.type import Snapshot
-
-
-def _fails_with(mocker: MockerFixture, error: bytes) -> None:
-    mocker.patch.object(process, "run", return_value=subprocess.CompletedProcess([], 1, b"", error))
 
 
 class TestDestroy:
@@ -27,12 +21,12 @@ class TestDestroy:
 
     def test_reports_stderr_without_line_endings(
         self,
-        mocker: MockerFixture,
+        fails_with: Callable[[bytes], None],
         ssh_command: Command,
         snapshot: Snapshot,
     ) -> None:
         """A failed destroy names the reason without the shell's trailing line ending."""
-        _fails_with(mocker, b"could not find any snapshots to destroy\r\n")
+        fails_with(b"could not find any snapshots to destroy\r\n")
 
         with pytest.raises(ZFSReplicateError) as raised:
             destroy(snapshot, ssh_command)
@@ -43,12 +37,12 @@ class TestDestroy:
 
     def test_reports_stderr_without_the_none_cipher_warning(
         self,
-        mocker: MockerFixture,
+        fails_with: Callable[[bytes], None],
         ssh_command: Command,
         snapshot: Snapshot,
     ) -> None:
         """The ssh banner does not reach a failed destroy's message."""
-        _fails_with(mocker, b"WARNING: ENABLED NONE CIPHERcould not find any snapshots to destroy")
+        fails_with(b"WARNING: ENABLED NONE CIPHERcould not find any snapshots to destroy")
 
         with pytest.raises(ZFSReplicateError) as raised:
             destroy(snapshot, ssh_command)

--- a/zfs_test/replicate_test/snapshot_test/destroy_test.py
+++ b/zfs_test/replicate_test/snapshot_test/destroy_test.py
@@ -3,6 +3,7 @@
 import subprocess
 
 import pytest
+from pytest_mock import MockerFixture
 
 from zfs.replicate import process
 from zfs.replicate.command import Command
@@ -11,35 +12,46 @@ from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.destroy import destroy
 from zfs.replicate.snapshot.type import Snapshot
 
-SSH = Command.with_empty_env("ssh", "host")
-SNAPSHOT = Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
+
+def _fails_with(mocker: MockerFixture, error: bytes) -> None:
+    mocker.patch.object(process, "run", return_value=subprocess.CompletedProcess([], 1, b"", error))
 
 
-def _fails_with(monkeypatch: pytest.MonkeyPatch, error: bytes) -> None:
-    def fake_run(command: Command, **_kwargs: object) -> "subprocess.CompletedProcess[bytes]":
-        return subprocess.CompletedProcess(command.argv, 1, b"", error)
+class TestDestroy:
+    """``destroy`` removes a remote snapshot, reporting why a failed removal failed."""
 
-    monkeypatch.setattr(process, "run", fake_run)
+    @pytest.fixture
+    def snapshot(self) -> Snapshot:
+        """Name the remote snapshot a destroy targets."""
+        return Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
 
+    def test_reports_stderr_without_line_endings(
+        self,
+        mocker: MockerFixture,
+        ssh_command: Command,
+        snapshot: Snapshot,
+    ) -> None:
+        """A failed destroy names the reason without the shell's trailing line ending."""
+        _fails_with(mocker, b"could not find any snapshots to destroy\r\n")
 
-def test_destroy_reports_stderr_without_line_endings(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A failed destroy names the reason without the shell's trailing line ending."""
-    _fails_with(monkeypatch, b"could not find any snapshots to destroy\r\n")
+        with pytest.raises(ZFSReplicateError) as raised:
+            destroy(snapshot, ssh_command)
 
-    with pytest.raises(ZFSReplicateError) as raised:
-        destroy(SNAPSHOT, SSH)
+        assert "could not find any snapshots to destroy" in raised.value.message
+        assert "\\r" not in raised.value.message
+        assert "\\n" not in raised.value.message
 
-    assert "could not find any snapshots to destroy" in raised.value.message
-    assert "\\r" not in raised.value.message
-    assert "\\n" not in raised.value.message
+    def test_reports_stderr_without_the_none_cipher_warning(
+        self,
+        mocker: MockerFixture,
+        ssh_command: Command,
+        snapshot: Snapshot,
+    ) -> None:
+        """The ssh banner does not reach a failed destroy's message."""
+        _fails_with(mocker, b"WARNING: ENABLED NONE CIPHERcould not find any snapshots to destroy")
 
+        with pytest.raises(ZFSReplicateError) as raised:
+            destroy(snapshot, ssh_command)
 
-def test_destroy_reports_stderr_without_the_none_cipher_warning(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The ssh banner does not reach a failed destroy's message."""
-    _fails_with(monkeypatch, b"WARNING: ENABLED NONE CIPHERcould not find any snapshots to destroy")
-
-    with pytest.raises(ZFSReplicateError) as raised:
-        destroy(SNAPSHOT, SSH)
-
-    assert "could not find any snapshots to destroy" in raised.value.message
-    assert "NONE CIPHER" not in raised.value.message
+        assert "could not find any snapshots to destroy" in raised.value.message
+        assert "NONE CIPHER" not in raised.value.message

--- a/zfs_test/replicate_test/snapshot_test/destroy_test.py
+++ b/zfs_test/replicate_test/snapshot_test/destroy_test.py
@@ -12,7 +12,7 @@ from zfs.replicate.snapshot.type import Snapshot
 
 
 class TestDestroy:
-    """``destroy`` removes a remote snapshot, reporting why a failed removal failed."""
+    """A failed destroy raises with the remote's reason, and nothing else."""
 
     @pytest.fixture
     def snapshot(self) -> Snapshot:

--- a/zfs_test/replicate_test/snapshot_test/list_test.py
+++ b/zfs_test/replicate_test/snapshot_test/list_test.py
@@ -10,24 +10,29 @@ from zfs.replicate.snapshot.type import Snapshot
 from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
-@given(lists(SNAPSHOTS))
-def test_snapshots(snapshots: List[Snapshot]) -> None:
-    """_snapshots."""
-    output = "\n".join([_output(s) for s in snapshots])
-    assert _snapshots(output.encode()) == snapshots
+class TestList:
+    """``list`` reads ``zfs list`` output back into snapshots.
 
+    Its parsing helpers, ``_snapshots`` and ``_snapshot``, carry that reading
+    and are exercised here without a remote listing to run.
+    """
 
-@given(lists(SNAPSHOTS, min_size=1))
-def test_snapshots_depth(snapshots: List[Snapshot]) -> None:
-    """Ensure max depth of 2."""
-    output = "\n".join([_output(s) for s in snapshots])
-    assert max(map(_depth, _snapshots(output.encode()))) <= 2
+    @given(lists(SNAPSHOTS))
+    def test_snapshots(self, snapshots: List[Snapshot]) -> None:
+        """_snapshots."""
+        output = "\n".join([_output(s) for s in snapshots])
+        assert _snapshots(output.encode()) == snapshots
 
+    @given(lists(SNAPSHOTS, min_size=1))
+    def test_snapshots_depth(self, snapshots: List[Snapshot]) -> None:
+        """Ensure max depth of 2."""
+        output = "\n".join([_output(s) for s in snapshots])
+        assert max(map(_depth, _snapshots(output.encode()))) <= 2
 
-@given(SNAPSHOTS)
-def test_snapshot(snapshot: Snapshot) -> None:
-    """_snapshot."""
-    assert _snapshot(_output(snapshot).encode()) == snapshot
+    @given(SNAPSHOTS)
+    def test_snapshot(self, snapshot: Snapshot) -> None:
+        """_snapshot."""
+        assert _snapshot(_output(snapshot).encode()) == snapshot
 
 
 def _output(snapshot: Snapshot) -> str:

--- a/zfs_test/replicate_test/snapshot_test/list_test.py
+++ b/zfs_test/replicate_test/snapshot_test/list_test.py
@@ -11,10 +11,10 @@ from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
 
 
 class TestList:
-    """``list`` reads ``zfs list`` output back into snapshots.
+    """Rendered ``zfs list`` output parses back to the snapshots it came from.
 
-    Its parsing helpers, ``_snapshots`` and ``_snapshot``, carry that reading
-    and are exercised here without a remote listing to run.
+    ``_snapshots`` and ``_snapshot`` do that parsing, so the tests below reach
+    for them directly.
     """
 
     @given(lists(SNAPSHOTS))

--- a/zfs_test/replicate_test/snapshot_test/send_test.py
+++ b/zfs_test/replicate_test/snapshot_test/send_test.py
@@ -112,7 +112,7 @@ class TestSend:
                 ssh_command=ssh_command,
                 compression=compression,
                 send_options=Options(),
-                receive_options=ReceiveOptions(),
+                receive_options=RECEIVE_DEFAULTS,
             )
 
         return _replicate

--- a/zfs_test/replicate_test/snapshot_test/send_test.py
+++ b/zfs_test/replicate_test/snapshot_test/send_test.py
@@ -53,10 +53,10 @@ class _FakeProcess:
 
 
 class TestSend:
-    """``send`` replicates a snapshot to a remote filesystem.
+    """``send`` assembles the replication stages, then runs them.
 
-    Its assembly helpers, ``_pipeline`` and ``_send``, render the stages that
-    replication runs and are exercised here without spawning a process.
+    ``_pipeline`` and ``_send`` render those stages without running them, so
+    the tests below reach for them directly.
     """
 
     @pytest.fixture

--- a/zfs_test/replicate_test/snapshot_test/send_test.py
+++ b/zfs_test/replicate_test/snapshot_test/send_test.py
@@ -1,21 +1,20 @@
 """zfs.replicate.snapshot.send tests."""
 
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import pytest
+from pytest_mock import MockerFixture
 
 from zfs.replicate import process
 from zfs.replicate.command import Command
 from zfs.replicate.compress.type import Compression
 from zfs.replicate.error import ZFSReplicateError
-from zfs.replicate.filesystem.type import filesystem
+from zfs.replicate.filesystem.type import FileSystem, filesystem
 from zfs.replicate.receive.type import Options as ReceiveOptions
 from zfs.replicate.send.type import Options
 from zfs.replicate.snapshot.send import Pipeline, _pipeline, _send, send
 from zfs.replicate.snapshot.type import Snapshot
 
-REMOTE = filesystem("backup")
-SSH = Command.with_empty_env("ssh", "host")
 RECEIVE_DEFAULTS = ReceiveOptions()
 
 
@@ -25,23 +24,6 @@ def _snapshot(name: str = "pool/data", snapshot: str = "snap") -> Snapshot:
         name=snapshot,
         previous=None,
         timestamp=0,
-    )
-
-
-def _assemble(
-    *,
-    compression: Compression = Compression.OFF,
-    receive_options: ReceiveOptions = RECEIVE_DEFAULTS,
-    previous: Optional[Snapshot] = None,
-) -> Pipeline:
-    return _pipeline(
-        REMOTE,
-        _snapshot(),
-        ssh_command=SSH,
-        compression=compression,
-        send_options=Options(),
-        receive_options=receive_options,
-        previous=previous,
     )
 
 
@@ -70,132 +52,197 @@ class _FakeProcess:
         return (b"", self._error)
 
 
-def _capture_spawns(monkeypatch: pytest.MonkeyPatch, returncode: int = 0, error: bytes = b"") -> List[_FakeProcess]:
-    """Replace the process boundary and collect the processes it hands back."""
-    spawned: List[_FakeProcess] = []
+class TestSend:
+    """``send`` replicates a snapshot to a remote filesystem.
 
-    def fake_open(command: Command, **_kwargs: object) -> _FakeProcess:
-        spawned.append(_FakeProcess(command, returncode, error))
+    Its assembly helpers, ``_pipeline`` and ``_send``, render the stages that
+    replication runs and are exercised here without spawning a process.
+    """
 
-        return spawned[-1]
+    @pytest.fixture
+    def remote(self) -> FileSystem:
+        """Name the remote filesystem replication sends to."""
+        return filesystem("backup")
 
-    monkeypatch.setattr(process, "open", fake_open)
+    @pytest.fixture
+    def snapshot(self) -> Snapshot:
+        """Name the snapshot replication sends."""
+        return _snapshot()
 
-    return spawned
+    @pytest.fixture
+    def assemble(
+        self,
+        remote: FileSystem,
+        snapshot: Snapshot,
+        ssh_command: Command,
+    ) -> Callable[..., Pipeline]:
+        """Assemble a replication pipeline, varying one input at a time."""
 
+        def _assemble(
+            *,
+            compression: Compression = Compression.OFF,
+            receive_options: ReceiveOptions = RECEIVE_DEFAULTS,
+            previous: Optional[Snapshot] = None,
+        ) -> Pipeline:
+            return _pipeline(
+                remote,
+                snapshot,
+                ssh_command=ssh_command,
+                compression=compression,
+                send_options=Options(),
+                receive_options=receive_options,
+                previous=previous,
+            )
 
-def _replicate(compression: Compression = Compression.OFF) -> None:
-    send(
-        REMOTE,
-        _snapshot(),
-        ssh_command=SSH,
-        compression=compression,
-        send_options=Options(),
-        receive_options=RECEIVE_DEFAULTS,
-    )
+        return _assemble
 
+    @pytest.fixture
+    def replicate(
+        self,
+        remote: FileSystem,
+        snapshot: Snapshot,
+        ssh_command: Command,
+    ) -> Callable[..., None]:
+        """Run a replication, varying one input at a time."""
 
-def test_send_renders_enabled_flags() -> None:
-    """_send embeds the -X flag for each enabled send option."""
-    command = _send(_snapshot(), options=Options(large_block=True, props=True))
+        def _replicate(compression: Compression = Compression.OFF) -> None:
+            send(
+                remote,
+                snapshot,
+                ssh_command=ssh_command,
+                compression=compression,
+                send_options=Options(),
+                receive_options=ReceiveOptions(),
+            )
 
-    assert "-L" in command.args
-    assert "-p" in command.args
+        return _replicate
 
+    @pytest.fixture
+    def capture_spawns(self, mocker: MockerFixture) -> Callable[..., List[_FakeProcess]]:
+        """Replace the process boundary and collect the processes it hands back."""
 
-def test_send_omits_disabled_flags() -> None:
-    """_send leaves out the -X flag for each disabled send option."""
-    command = _send(_snapshot(), options=Options(raw=False))
+        def _capture_spawns(returncode: int = 0, error: bytes = b"") -> List[_FakeProcess]:
+            spawned: List[_FakeProcess] = []
 
-    assert "-w" not in command.args
-    assert "-L" not in command.args
+            def fake_open(command: Command, **_kwargs: object) -> _FakeProcess:
+                spawned.append(_FakeProcess(command, returncode, error))
 
+                return spawned[-1]
 
-def test_send_keeps_hostile_snapshot_as_one_token() -> None:
-    """A snapshot name with shell metacharacters stays a single argv token."""
-    command = _send(_snapshot("pool/data a$b"), options=Options())
+            mocker.patch.object(process, "open", fake_open)
 
-    assert command.args[-1] == "pool/data a$b@snap"
-    assert "'pool/data a$b@snap'" in command.render()
+            return spawned
 
+        return _capture_spawns
 
-def test_pipeline_drops_both_compression_stages_when_off() -> None:
-    """OFF leaves no local compressor and no remote decompress prefix."""
-    pipeline = _assemble(compression=Compression.OFF)
+    def test_send_renders_enabled_flags(self, snapshot: Snapshot) -> None:
+        """_send embeds the -X flag for each enabled send option."""
+        command = _send(snapshot, options=Options(large_block=True, props=True))
 
-    assert pipeline.send.args[-1] == "pool/data@snap"
-    assert pipeline.compress is None
-    assert pipeline.receive.args[-1] == "/usr/bin/env - zfs receive -F -d backup/pool"
+        assert "-L" in command.args
+        assert "-p" in command.args
 
+    def test_send_omits_disabled_flags(self, snapshot: Snapshot) -> None:
+        """_send leaves out the -X flag for each disabled send option."""
+        command = _send(snapshot, options=Options(raw=False))
 
-def test_pipeline_pairs_the_compressor_with_a_remote_decompress() -> None:
-    """lz4 compresses locally and decompresses ahead of the remote receive."""
-    pipeline = _assemble(compression=Compression.LZ4)
+        assert "-w" not in command.args
+        assert "-L" not in command.args
 
-    assert pipeline.compress is not None
-    assert pipeline.compress.argv == ["/usr/bin/env", "-", "lz4"]
-    assert pipeline.receive.args[-1] == "/usr/bin/env - lz4 -d | /usr/bin/env - zfs receive -F -d backup/pool"
+    def test_send_keeps_hostile_snapshot_as_one_token(self) -> None:
+        """A snapshot name with shell metacharacters stays a single argv token."""
+        command = _send(_snapshot("pool/data a$b"), options=Options())
 
+        assert command.args[-1] == "pool/data a$b@snap"
+        assert "'pool/data a$b@snap'" in command.render()
 
-def test_pipeline_hands_the_remote_side_to_ssh() -> None:
-    """The remote pipeline rides as a single argument to the configured ssh command."""
-    pipeline = _assemble()
+    def test_pipeline_drops_both_compression_stages_when_off(self, assemble: Callable[..., Pipeline]) -> None:
+        """OFF leaves no local compressor and no remote decompress prefix."""
+        pipeline = assemble(compression=Compression.OFF)
 
-    assert pipeline.receive.argv[:4] == ["/usr/bin/env", "-", "ssh", "host"]
-    assert len(pipeline.receive.argv) == 5
+        assert pipeline.send.args[-1] == "pool/data@snap"
+        assert pipeline.compress is None
+        assert pipeline.receive.args[-1] == "/usr/bin/env - zfs receive -F -d backup/pool"
 
+    def test_pipeline_pairs_the_compressor_with_a_remote_decompress(self, assemble: Callable[..., Pipeline]) -> None:
+        """lz4 compresses locally and decompresses ahead of the remote receive."""
+        pipeline = assemble(compression=Compression.LZ4)
 
-def test_pipeline_marks_an_incremental_send_with_its_previous_snapshot() -> None:
-    """A previous snapshot becomes the -i source of the send stage."""
-    pipeline = _assemble(previous=_snapshot(snapshot="older"))
+        assert pipeline.compress is not None
+        assert pipeline.compress.argv == ["/usr/bin/env", "-", "lz4"]
+        assert pipeline.receive.args[-1] == "/usr/bin/env - lz4 -d | /usr/bin/env - zfs receive -F -d backup/pool"
 
-    assert pipeline.send.args[-3:] == ["-i", "pool/data@older", "pool/data@snap"]
+    def test_pipeline_hands_the_remote_side_to_ssh(self, assemble: Callable[..., Pipeline]) -> None:
+        """The remote pipeline rides as a single argument to the configured ssh command."""
+        pipeline = assemble()
 
+        assert pipeline.receive.argv[:4] == ["/usr/bin/env", "-", "ssh", "host"]
+        assert len(pipeline.receive.argv) == 5
 
-def test_pipeline_omits_the_incremental_flag_for_a_full_send() -> None:
-    """Without a previous snapshot the send stage carries no -i source."""
-    pipeline = _assemble()
+    def test_pipeline_marks_an_incremental_send_with_its_previous_snapshot(
+        self,
+        assemble: Callable[..., Pipeline],
+    ) -> None:
+        """A previous snapshot becomes the -i source of the send stage."""
+        pipeline = assemble(previous=_snapshot(snapshot="older"))
 
-    assert "-i" not in pipeline.send.args
+        assert pipeline.send.args[-3:] == ["-i", "pool/data@older", "pool/data@snap"]
 
+    def test_pipeline_omits_the_incremental_flag_for_a_full_send(self, assemble: Callable[..., Pipeline]) -> None:
+        """Without a previous snapshot the send stage carries no -i source."""
+        pipeline = assemble()
 
-def test_pipeline_threads_receive_options_into_the_remote_side() -> None:
-    """Non-default receive settings reach the remote zfs receive invocation."""
-    pipeline = _assemble(
-        receive_options=ReceiveOptions(force=False, no_mount=True, resume=True, properties={"readonly": "on"}),
-    )
+        assert "-i" not in pipeline.send.args
 
-    assert pipeline.receive.args[-1] == "/usr/bin/env - zfs receive -u -s -o readonly=on -d backup/pool"
+    def test_pipeline_threads_receive_options_into_the_remote_side(self, assemble: Callable[..., Pipeline]) -> None:
+        """Non-default receive settings reach the remote zfs receive invocation."""
+        pipeline = assemble(
+            receive_options=ReceiveOptions(force=False, no_mount=True, resume=True, properties={"readonly": "on"}),
+        )
 
+        assert pipeline.receive.args[-1] == "/usr/bin/env - zfs receive -u -s -o readonly=on -d backup/pool"
 
-def test_send_spawns_each_assembled_stage(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Each assembled stage runs as a process, in pipeline order."""
-    spawned = _capture_spawns(monkeypatch)
+    def test_send_spawns_each_assembled_stage(
+        self,
+        capture_spawns: Callable[..., List[_FakeProcess]],
+        replicate: Callable[..., None],
+    ) -> None:
+        """Each assembled stage runs as a process, in pipeline order."""
+        spawned = capture_spawns()
 
-    _replicate(compression=Compression.LZ4)
+        replicate(compression=Compression.LZ4)
 
-    assert [proc.command.args[1] for proc in spawned] == ["zfs", "lz4", "ssh"]
+        assert [proc.command.args[1] for proc in spawned] == ["zfs", "lz4", "ssh"]
 
+    def test_send_detaches_the_parent_from_every_upstream_stage(
+        self,
+        capture_spawns: Callable[..., List[_FakeProcess]],
+        replicate: Callable[..., None],
+    ) -> None:
+        """The parent closes every piped stdout but the last, whose output it reads."""
+        spawned = capture_spawns()
 
-def test_send_detaches_the_parent_from_every_upstream_stage(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The parent closes every piped stdout but the last, whose output it reads."""
-    spawned = _capture_spawns(monkeypatch)
+        replicate(compression=Compression.LZ4)
 
-    _replicate(compression=Compression.LZ4)
+        assert [proc.stdout.closed for proc in spawned] == [True, True, False]
 
-    assert [proc.stdout.closed for proc in spawned] == [True, True, False]
+    def test_send_ignores_a_missing_mountpoint(
+        self,
+        capture_spawns: Callable[..., List[_FakeProcess]],
+        replicate: Callable[..., None],
+    ) -> None:
+        """Replication tolerates a failure to create the destination mountpoint."""
+        capture_spawns(returncode=1, error=b"cannot mount 'backup/pool': failed to create mountpoint")
 
+        replicate()
 
-def test_send_ignores_a_missing_mountpoint(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replication tolerates a failure to create the destination mountpoint."""
-    _capture_spawns(monkeypatch, returncode=1, error=b"cannot mount 'backup/pool': failed to create mountpoint")
+    def test_send_raises_on_any_other_failure(
+        self,
+        capture_spawns: Callable[..., List[_FakeProcess]],
+        replicate: Callable[..., None],
+    ) -> None:
+        """A failed pipeline surfaces its stderr as a ZFSReplicateError."""
+        capture_spawns(returncode=1, error=b"cannot receive: dataset does not exist")
 
-    _replicate()
-
-
-def test_send_raises_on_any_other_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A failed pipeline surfaces its stderr as a ZFSReplicateError."""
-    _capture_spawns(monkeypatch, returncode=1, error=b"cannot receive: dataset does not exist")
-
-    with pytest.raises(ZFSReplicateError, match="pool/data@snap"):
-        _replicate()
+        with pytest.raises(ZFSReplicateError, match="pool/data@snap"):
+            replicate()

--- a/zfs_test/replicate_test/snapshot_test/strategies_test.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies_test.py
@@ -9,7 +9,7 @@ from zfs.replicate.snapshot.type import Snapshot
 
 
 class TestSnapshots:
-    """``SNAPSHOTS`` draws the snapshots the suite's property tests run on."""
+    """Drawn snapshots vary their filesystem name."""
 
     def test_vary_filesystem(self) -> None:
         """SNAPSHOTS draws more than one filesystem name."""

--- a/zfs_test/replicate_test/snapshot_test/strategies_test.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies_test.py
@@ -8,9 +8,12 @@ import zfs_test.replicate_test.snapshot_test.strategies as sut
 from zfs.replicate.snapshot.type import Snapshot
 
 
-def test_snapshots_vary_filesystem() -> None:
-    """SNAPSHOTS draws more than one filesystem name."""
-    assert len(_drawn_filesystem_names()) > 1
+class TestSnapshots:
+    """``SNAPSHOTS`` draws the snapshots the suite's property tests run on."""
+
+    def test_vary_filesystem(self) -> None:
+        """SNAPSHOTS draws more than one filesystem name."""
+        assert len(_drawn_filesystem_names()) > 1
 
 
 def _drawn_filesystem_names() -> Set[str]:

--- a/zfs_test/replicate_test/snapshot_test/type_test.py
+++ b/zfs_test/replicate_test/snapshot_test/type_test.py
@@ -4,27 +4,28 @@ from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.type import Snapshot
 
 
-def test_eq_ignore_previous() -> None:
-    """Ignore previous in Snapshot equality."""
-    zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
-    previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
-    assert zero == previous
+class TestSnapshotEq:
+    """``Snapshot.__eq__`` matches a local snapshot to its remote counterpart."""
 
+    def test_ignore_previous(self) -> None:
+        """Ignore previous in Snapshot equality."""
+        zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
+        previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
+        assert zero == previous
 
-def test_eq_rejects_unaligned_suffix() -> None:
-    """Snapshots on unrelated datasets sharing a name suffix are not equal."""
-    local = Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
-    remote = Snapshot(filesystem=filesystem("bigpool/data"), name="snap", previous=None, timestamp=0)
-    assert local != remote
+    def test_rejects_unaligned_suffix(self) -> None:
+        """Snapshots on unrelated datasets sharing a name suffix are not equal."""
+        local = Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
+        remote = Snapshot(filesystem=filesystem("bigpool/data"), name="snap", previous=None, timestamp=0)
+        assert local != remote
 
-
-def test_eq_accepts_slash_aligned_suffix() -> None:
-    """A remote rebased under another dataset stays equal to its local origin."""
-    local = Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
-    remote = Snapshot(
-        filesystem=filesystem("backup/pool/data"),
-        name="snap",
-        previous=None,
-        timestamp=0,
-    )
-    assert local == remote
+    def test_accepts_slash_aligned_suffix(self) -> None:
+        """A remote rebased under another dataset stays equal to its local origin."""
+        local = Snapshot(filesystem=filesystem("pool/data"), name="snap", previous=None, timestamp=0)
+        remote = Snapshot(
+            filesystem=filesystem("backup/pool/data"),
+            name="snap",
+            previous=None,
+            timestamp=0,
+        )
+        assert local == remote

--- a/zfs_test/replicate_test/stderr_test.py
+++ b/zfs_test/replicate_test/stderr_test.py
@@ -3,21 +3,23 @@
 import zfs.replicate.stderr as sut
 
 
-def test_clean_keeps_a_plain_message_intact() -> None:
-    """Stderr carrying no noise survives unchanged."""
-    assert sut.clean(b"cannot destroy 'pool/data': dataset is busy") == b"cannot destroy 'pool/data': dataset is busy"
+class TestClean:
+    """``clean`` strips the noise a remote shell adds around an error message."""
 
+    def test_keeps_a_plain_message_intact(self) -> None:
+        """Stderr carrying no noise survives unchanged."""
+        assert (
+            sut.clean(b"cannot destroy 'pool/data': dataset is busy") == b"cannot destroy 'pool/data': dataset is busy"
+        )
 
-def test_clean_drops_trailing_line_endings() -> None:
-    """The line ending a shell appends does not reach the error message."""
-    assert sut.clean(b"cannot open 'pool/data'\r\n") == b"cannot open 'pool/data'"
+    def test_drops_trailing_line_endings(self) -> None:
+        """The line ending a shell appends does not reach the error message."""
+        assert sut.clean(b"cannot open 'pool/data'\r\n") == b"cannot open 'pool/data'"
 
+    def test_drops_the_none_cipher_warning(self) -> None:
+        """The banner an unencrypted ssh session prints is not an error."""
+        assert sut.clean(b"WARNING: ENABLED NONE CIPHER\r\n") == b""
 
-def test_clean_drops_the_none_cipher_warning() -> None:
-    """The banner an unencrypted ssh session prints is not an error."""
-    assert sut.clean(b"WARNING: ENABLED NONE CIPHER\r\n") == b""
-
-
-def test_clean_keeps_a_message_the_none_cipher_warning_precedes() -> None:
-    """The failure reported after the banner survives its removal."""
-    assert sut.clean(b"WARNING: ENABLED NONE CIPHERcannot open 'pool/data'\n") == b"cannot open 'pool/data'"
+    def test_keeps_a_message_the_none_cipher_warning_precedes(self) -> None:
+        """The failure reported after the banner survives its removal."""
+        assert sut.clean(b"WARNING: ENABLED NONE CIPHERcannot open 'pool/data'\n") == b"cannot open 'pool/data'"

--- a/zfs_test/replicate_test/stderr_test.py
+++ b/zfs_test/replicate_test/stderr_test.py
@@ -4,7 +4,7 @@ import zfs.replicate.stderr as sut
 
 
 class TestClean:
-    """``clean`` strips the noise a remote shell adds around an error message."""
+    """The shell's noise goes and the message it wrapped survives."""
 
     def test_keeps_a_plain_message_intact(self) -> None:
         """Stderr carrying no noise survives unchanged."""

--- a/zfs_test/replicate_test/task_test/execute_test.py
+++ b/zfs_test/replicate_test/task_test/execute_test.py
@@ -15,7 +15,7 @@ from zfs.replicate.task.type import Action, Task
 
 
 class TestExecute:
-    """``execute`` dispatches each task to the operation it names."""
+    """Dispatching a task reports it through the ``zfs.replicate`` logger."""
 
     def test_send_dispatch_logs(
         self,

--- a/zfs_test/replicate_test/task_test/execute_test.py
+++ b/zfs_test/replicate_test/task_test/execute_test.py
@@ -1,9 +1,9 @@
 """zfs.replicate.task.execute tests."""
 
 import logging
-from typing import Any
 
 import pytest
+from pytest_mock import MockerFixture
 
 from zfs.replicate import receive, send, snapshot
 from zfs.replicate.command import Command
@@ -14,32 +14,35 @@ from zfs.replicate.task.execute import execute
 from zfs.replicate.task.type import Action, Task
 
 
-def test_send_dispatch_logs(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Dispatching a SEND task logs the snapshot at INFO."""
+class TestExecute:
+    """``execute`` dispatches each task to the operation it names."""
 
-    def fake_send(*_args: Any, **_kwargs: Any) -> None:
-        return None
+    def test_send_dispatch_logs(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        mocker: MockerFixture,
+    ) -> None:
+        """Dispatching a SEND task logs the snapshot at INFO."""
+        mocker.patch.object(snapshot, "send")
+        # click_log.basic_config disables propagation on zfs.replicate, so caplog
+        # (which captures via the root logger) sees nothing without this.
+        mocker.patch.object(logging.getLogger("zfs.replicate"), "propagate", True)
 
-    monkeypatch.setattr(snapshot, "send", fake_send)
-    # click_log.basic_config disables propagation on zfs.replicate, so caplog
-    # (which captures via the root logger) sees nothing without this.
-    monkeypatch.setattr(logging.getLogger("zfs.replicate"), "propagate", True)
+        local = filesystem("tank/data")
+        snap = Snapshot(filesystem=local, name="snap1", previous=None, timestamp=0)
+        task = Task(action=Action.SEND, filesystem=local, snapshot=snap)
 
-    local = filesystem("tank/data")
-    snap = Snapshot(filesystem=local, name="snap1", previous=None, timestamp=0)
-    task = Task(action=Action.SEND, filesystem=local, snapshot=snap)
+        with caplog.at_level(logging.INFO, logger="zfs.replicate"):
+            execute(
+                filesystem("backup"),
+                [(local, [task])],
+                ssh_command=Command("ssh", ["backup.example.com"]),
+                compression=Compression.LZ4,
+                send_options=send.Options(large_block=False, raw=True, embed=False, compressed=False, props=False),
+                receive_options=receive.Options(force=True, no_mount=False, resume=False, properties={}),
+            )
 
-    with caplog.at_level(logging.INFO, logger="zfs.replicate"):
-        execute(
-            filesystem("backup"),
-            [(local, [task])],
-            ssh_command=Command("ssh", ["backup.example.com"]),
-            compression=Compression.LZ4,
-            send_options=send.Options(large_block=False, raw=True, embed=False, compressed=False, props=False),
-            receive_options=receive.Options(force=True, no_mount=False, resume=False, properties={}),
-        )
-
-    # Assert on the snapshot identity, not the exact phrasing, so rewording the
-    # progress message doesn't fail this.
-    dispatch = [r for r in caplog.records if r.levelno == logging.INFO]
-    assert any("tank/data@snap1" in r.getMessage() for r in dispatch)
+        # Assert on the snapshot identity, not the exact phrasing, so rewording the
+        # progress message doesn't fail this.
+        dispatch = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("tank/data@snap1" in r.getMessage() for r in dispatch)

--- a/zfs_test/replicate_test/task_test/generate_test.py
+++ b/zfs_test/replicate_test/task_test/generate_test.py
@@ -30,9 +30,8 @@ _UNSENT = _snapshot(_LOCAL, "unsent", 2)
 _STALE = _snapshot(_DESTINATION, "stale", 3)
 
 
-# Drawn snapshots reach a test as a flat list; generate takes them keyed by
-# filesystem. A fixture cannot do the grouping, since the value it groups is
-# drawn per example rather than resolved once.
+# A fixture cannot do this grouping: the value it groups is drawn per example
+# rather than resolved once.
 def _by_filesystem(snapshots: Iterable[Snapshot]) -> Dict[FileSystem, List[Snapshot]]:
     return {
         k: list(v)
@@ -44,7 +43,7 @@ def _by_filesystem(snapshots: Iterable[Snapshot]) -> Dict[FileSystem, List[Snaps
 
 
 class TestGenerate:
-    """``generate`` turns a local and a remote snapshot listing into a task list."""
+    """The two listings decide which tasks run, and in what order."""
 
     def test_no_tasks(self) -> None:
         """generate(Any, {}, {}) == []."""

--- a/zfs_test/replicate_test/task_test/generate_test.py
+++ b/zfs_test/replicate_test/task_test/generate_test.py
@@ -2,7 +2,7 @@
 
 import itertools
 import operator
-from typing import List
+from typing import Dict, Iterable, List
 
 from hypothesis import given
 from hypothesis.strategies import lists
@@ -13,70 +13,6 @@ from zfs.replicate.snapshot import Snapshot
 from zfs.replicate.task.generate import generate
 from zfs.replicate.task.type import Action
 from zfs_test.replicate_test.snapshot_test.strategies import SNAPSHOTS
-
-
-def test_no_tasks() -> None:
-    """generate(Any, {}, {}) == []."""
-    assert not generate(filesystem("pool/filesystem"), {}, {})
-
-
-@given(lists(SNAPSHOTS))
-def test_empty_remotes(snapshots: List[Snapshot]) -> None:
-    """Generate with empty remotes."""
-    snapshots_by_fs = {
-        k: list(v)
-        for (k, v) in itertools.groupby(
-            sorted(snapshots, key=operator.attrgetter("filesystem")),
-            key=operator.attrgetter("filesystem"),
-        )
-    }
-
-    result = generate(filesystem(""), snapshots_by_fs, {})
-
-    assert len([t for t in result if t.action == Action.CREATE and t.snapshot is None]) == len(snapshots_by_fs)
-    assert len([t for t in result if t.action == Action.SEND and t.snapshot is not None]) == sum(
-        map(len, snapshots_by_fs.values()),
-    )
-
-
-@given(lists(SNAPSHOTS))
-def test_empty_locals(snapshots: List[Snapshot]) -> None:
-    """Generate with empty locals."""
-    snapshots_by_fs = {
-        k: list(v)
-        for (k, v) in itertools.groupby(
-            sorted(snapshots, key=operator.attrgetter("filesystem")),
-            key=operator.attrgetter("filesystem"),
-        )
-    }
-
-    result = generate(filesystem(""), {}, snapshots_by_fs)
-
-    assert len([t for t in result if t.action == Action.DESTROY]) == len(snapshots_by_fs) + sum(
-        map(len, snapshots_by_fs.values()),
-    )
-    assert all(t.action == Action.DESTROY for t in result)
-
-
-@given(lists(SNAPSHOTS))
-def test_empty_locals_remote_prefixed(snapshots: List[Snapshot]) -> None:
-    """Generate with empty locals and prefixed remotes."""
-    remote = filesystem("backup")
-    snapshots_by_fs = {
-        remote_filesystem(remote, k): list(v)
-        for (k, v) in itertools.groupby(
-            sorted(snapshots, key=operator.attrgetter("filesystem")),
-            key=operator.attrgetter("filesystem"),
-        )
-    }
-
-    result = generate(remote, {}, snapshots_by_fs)
-
-    assert len([t for t in result if t.action == Action.DESTROY]) == len(snapshots_by_fs) + sum(
-        map(len, snapshots_by_fs.values()),
-    )
-    assert all(t.filesystem in snapshots_by_fs for t in result)
-
 
 _REMOTE = filesystem("backup")
 _LOCAL = filesystem("pool/filesystem")
@@ -94,28 +30,88 @@ _UNSENT = _snapshot(_LOCAL, "unsent", 2)
 _STALE = _snapshot(_DESTINATION, "stale", 3)
 
 
-def test_diverged_destroys_before_sending() -> None:
-    """Without a snapshot in common, the destroys precede the sends."""
-    result = generate(_REMOTE, {_LOCAL: [_UNSENT]}, {_DESTINATION: [_STALE]})
-
-    assert [(t.action, t.snapshot) for t in result] == [
-        (Action.DESTROY, _STALE),
-        (Action.SEND, _UNSENT),
-    ]
-
-
-def test_follow_delete_destroys_after_sending() -> None:
-    """With a snapshot in common, follow_delete prunes after the sends."""
-    result = generate(_REMOTE, {_LOCAL: [_SHARED, _UNSENT]}, {_DESTINATION: [_SHARED, _STALE]}, follow_delete=True)
-
-    assert [(t.action, t.snapshot) for t in result] == [
-        (Action.SEND, _UNSENT),
-        (Action.DESTROY, _STALE),
-    ]
+# Drawn snapshots reach a test as a flat list; generate takes them keyed by
+# filesystem. A fixture cannot do the grouping, since the value it groups is
+# drawn per example rather than resolved once.
+def _by_filesystem(snapshots: Iterable[Snapshot]) -> Dict[FileSystem, List[Snapshot]]:
+    return {
+        k: list(v)
+        for (k, v) in itertools.groupby(
+            sorted(snapshots, key=operator.attrgetter("filesystem")),
+            key=operator.attrgetter("filesystem"),
+        )
+    }
 
 
-def test_common_snapshot_keeps_the_remote_without_follow_delete() -> None:
-    """Without follow_delete, a snapshot missing locally survives on the remote."""
-    result = generate(_REMOTE, {_LOCAL: [_SHARED, _UNSENT]}, {_DESTINATION: [_SHARED, _STALE]})
+class TestGenerate:
+    """``generate`` turns a local and a remote snapshot listing into a task list."""
 
-    assert [(t.action, t.snapshot) for t in result] == [(Action.SEND, _UNSENT)]
+    def test_no_tasks(self) -> None:
+        """generate(Any, {}, {}) == []."""
+        assert not generate(filesystem("pool/filesystem"), {}, {})
+
+    @given(lists(SNAPSHOTS))
+    def test_empty_remotes(self, snapshots: List[Snapshot]) -> None:
+        """Generate with empty remotes."""
+        snapshots_by_fs = _by_filesystem(snapshots)
+
+        result = generate(filesystem(""), snapshots_by_fs, {})
+
+        assert len([t for t in result if t.action == Action.CREATE and t.snapshot is None]) == len(snapshots_by_fs)
+        assert len([t for t in result if t.action == Action.SEND and t.snapshot is not None]) == sum(
+            map(len, snapshots_by_fs.values()),
+        )
+
+    @given(lists(SNAPSHOTS))
+    def test_empty_locals(self, snapshots: List[Snapshot]) -> None:
+        """Generate with empty locals."""
+        snapshots_by_fs = _by_filesystem(snapshots)
+
+        result = generate(filesystem(""), {}, snapshots_by_fs)
+
+        assert len([t for t in result if t.action == Action.DESTROY]) == len(snapshots_by_fs) + sum(
+            map(len, snapshots_by_fs.values()),
+        )
+        assert all(t.action == Action.DESTROY for t in result)
+
+    @given(lists(SNAPSHOTS))
+    def test_empty_locals_remote_prefixed(self, snapshots: List[Snapshot]) -> None:
+        """Generate with empty locals and prefixed remotes."""
+        remote = filesystem("backup")
+        snapshots_by_fs = {remote_filesystem(remote, k): v for (k, v) in _by_filesystem(snapshots).items()}
+
+        result = generate(remote, {}, snapshots_by_fs)
+
+        assert len([t for t in result if t.action == Action.DESTROY]) == len(snapshots_by_fs) + sum(
+            map(len, snapshots_by_fs.values()),
+        )
+        assert all(t.filesystem in snapshots_by_fs for t in result)
+
+    def test_diverged_destroys_before_sending(self) -> None:
+        """Without a snapshot in common, the destroys precede the sends."""
+        result = generate(_REMOTE, {_LOCAL: [_UNSENT]}, {_DESTINATION: [_STALE]})
+
+        assert [(t.action, t.snapshot) for t in result] == [
+            (Action.DESTROY, _STALE),
+            (Action.SEND, _UNSENT),
+        ]
+
+    def test_follow_delete_destroys_after_sending(self) -> None:
+        """With a snapshot in common, follow_delete prunes after the sends."""
+        result = generate(
+            _REMOTE,
+            {_LOCAL: [_SHARED, _UNSENT]},
+            {_DESTINATION: [_SHARED, _STALE]},
+            follow_delete=True,
+        )
+
+        assert [(t.action, t.snapshot) for t in result] == [
+            (Action.SEND, _UNSENT),
+            (Action.DESTROY, _STALE),
+        ]
+
+    def test_common_snapshot_keeps_the_remote_without_follow_delete(self) -> None:
+        """Without follow_delete, a snapshot missing locally survives on the remote."""
+        result = generate(_REMOTE, {_LOCAL: [_SHARED, _UNSENT]}, {_DESTINATION: [_SHARED, _STALE]})
+
+        assert [(t.action, t.snapshot) for t in result] == [(Action.SEND, _UNSENT)]

--- a/zfs_test/replicate_test/task_test/report_test.py
+++ b/zfs_test/replicate_test/task_test/report_test.py
@@ -10,7 +10,7 @@ from zfs.replicate.task.type import Task
 
 
 class TestReport:
-    """``report`` renders the tasks a run will perform."""
+    """A report is empty exactly when there are no tasks."""
 
     def test_empty_tasks(self) -> None:
         """Ensure no actions is an empty report."""

--- a/zfs_test/replicate_test/task_test/report_test.py
+++ b/zfs_test/replicate_test/task_test/report_test.py
@@ -9,13 +9,15 @@ from zfs.replicate.task import report
 from zfs.replicate.task.type import Task
 
 
-def test_empty_tasks() -> None:
-    """Ensure no actions is an empty report."""
-    assert report([]) == ""
+class TestReport:
+    """``report`` renders the tasks a run will perform."""
 
+    def test_empty_tasks(self) -> None:
+        """Ensure no actions is an empty report."""
+        assert report([]) == ""
 
-@given(tasks=lists(builds(Task), min_size=1))
-def test_nonempty_tasks(tasks: List[Task]) -> None:
-    """Ensure nonempty report from nonempty actions."""
-    result = report(tasks)
-    assert result != ""
+    @given(tasks=lists(builds(Task), min_size=1))
+    def test_nonempty_tasks(self, tasks: List[Task]) -> None:
+        """Ensure nonempty report from nonempty actions."""
+        result = report(tasks)
+        assert result != ""


### PR DESCRIPTION
## Summary

`zfs_test/` groups each module's tests into one class per exported symbol, with shared setup injected as fixtures, so a module's class list reads as its public surface. Closes #486.

Both questions the issue left open are settled. A private helper's tests live in the class of the public symbol it serves, because a class per tested symbol collides in `snapshot/send.py`, which exports `send` and carries `_send`. And a `@given` test takes no fixtures, because a function-scoped fixture resolves once while Hypothesis runs the body many times over fresh examples.

The plugin audit kept `pytest-mock` and `pytest-randomly`. `pytest-xdist` went in and came back out: `-n auto` measured 7.9s against 6.5s serial, and #674 closed #485 with mutmut without reaching for it, so nothing passes `-n auto`. #676 carries the measurement it would need.

Four refactorings landed, one commit each: **Pull Up Method** and **Change Function Declaration** on the duplicated `_fails_with`; **Substitute Algorithm** on `TestValue.test_none`, retiring a `noqa: E722`; **Parameterize Function** and **Remove Dead Code** on the compression totality test; **Remove Dead Code** on six annotations mypy infers. Declined, so they don't get re-proposed: **Extract Superclass** on the two `TestDestroy` classes, since a base would parameterize away everything the tests say; `MagicMock` in place of the process fakes, which answers to any attribute and would pass contract drift silently; **Parameterize Function** on the `to_flags` tests, which would key options by string and lose the type checker; and three that belong elsewhere, in #679, #655, and **Decompose Conditional** on the `isinstance` assertion.

## Gotchas

- `TestList` and `TestSend` each hold three symbols' tests, which reads like the one-class-per-symbol rule breaking. It's the private-helper rule: `_snapshots`, `_pipeline`, and `_send` sit with the public symbol they serve.
- `_by_filesystem` in `generate_test.py` is a plain function where everything around it is a fixture. A fixture cannot group a value Hypothesis draws per example.
- The fourth acceptance criterion asks the Copilot instructions to describe the new layout, and #667 deleted those files. `CLAUDE.md` took the pointer instead, so that box stays unticked on purpose.

## Test plan

- Ran the suite repeatedly under `pytest-randomly`'s shuffle, confirming the new class-level fixtures introduced no order dependence.
- 78 passed, coverage unchanged at 92%. The one extra test is the compression check split into a case per member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN8GXy8un1YdxntFUYnhFg