### PR TITLE
test: keep property tests green under mutmut

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -120,3 +120,10 @@ A nightly job scores the suite by mutation testing, configured under
 survives is killed by a new test, recorded as an equivalent mutant in a comment
 at the code, or excluded with `# pragma: no mutate block` and the reason no test
 can reach it.
+
+`mutmut` runs the suite several times in one process, and `pytest` builds a
+fresh instance of a test class for each pass. Hypothesis reads those instances
+as a property test called from differing executors, so
+[`zfs_test/conftest.py`](../../zfs_test/conftest.py) suppresses that health
+check while `mutmut` drives the suite. A property test needs nothing of its own,
+and an ordinary `pytest` run leaves the check on.

--- a/zfs_test/conftest.py
+++ b/zfs_test/conftest.py
@@ -1,13 +1,25 @@
 """Fixtures shared across the suite."""
 
+import os
 import subprocess
 from typing import Callable
 
 import pytest
+from hypothesis import HealthCheck, settings
 from pytest_mock import MockerFixture
 
 from zfs.replicate import process
 from zfs.replicate.command import Command
+
+# mutmut runs the suite several times in one process---stats, clean tests, then
+# a pass per mutant---and pytest builds a fresh instance of a test class for
+# each pass. Hypothesis reads those instances as differing executors and fails
+# the health check on the second pass. The classes are namespaces that hold no
+# state between passes, so the check has nothing to catch under mutmut; an
+# ordinary pytest run, where it could catch something, keeps it on.
+if "MUTANT_UNDER_TEST" in os.environ:
+    settings.register_profile("mutmut", suppress_health_check=[HealthCheck.differing_executors])
+    settings.load_profile("mutmut")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

The nightly mutation sweep has failed since #675 moved the suite into
classes, so no score has been filed since. [The last
run](https://github.com/alunduil/zfs-replicate/actions/runs/32695453816/job/97336581523)
died on the clean-test gate, before it scored a single mutant:

```
FAILED zfs_test/replicate_test/list_test.py::TestInits::test_length -
hypothesis.errors.FailedHealthCheck: The method TestInits.test_length was called
from multiple different executors.
```

`mutmut` runs the tests several times in one process — stats, clean tests, then
a pass per mutant — and `pytest` builds a fresh instance of a test class for each
pass. Hypothesis compares the bound instance across calls of a `@given` method
and reads two of them as two executors, which is a correctness signal worth
having when a test really is driven from two places, and a false positive here:
the classes are namespaces, and nothing carries between passes. Module-level
property tests had no instance to compare, which is why this only appeared after
the move to classes.

`zfs_test/conftest.py` suppresses that one health check when `MUTANT_UNDER_TEST`
is set, the variable `mutmut` exports for the whole sweep. An ordinary `pytest`
run leaves the check on, so a real executor mixup still fails.

## Gotchas

- The gate is `mutmut`'s environment variable rather than a blanket suppression,
  which ties the fix to an implementation detail of a pinned dependency
  (`mutmut = "==3.7.0"`). A rename upstream brings the nightly failure back
  rather than silently dropping the check — the noisier of the two ways to be
  wrong.
- Hypothesis names this check one to fix rather than suppress, and the docs
  paragraph added under "Mutation testing" records why suppressing is the answer
  here, so the reasoning is not re-derived at the next occurrence.

## Test plan

- Reproduced the CI failure locally with `poetry run mutmut run --max-children 1`
  on `master`: same health check, same test, same abort at "Failed to run clean
  test".
- Re-ran the full sweep with the fix. It clears the clean-test gate and runs to
  completion over all 895 mutants: 443 killed, 298 survived, 154 unreached by any
  test, 0 timed out, 0 suspicious.
- Ran the two steps that follow the sweep in the job, `mutmut export-cicd-stats`
  and `.github/scripts/mutation-summary.sh`, which render "Killed 60% of the 741
  mutants a test reached." So the job produces a score issue end to end, not just
  a passing sweep. Killing what survived is separate work, tracked in #673 and
  #671.
- `poetry run pytest`: 78 passed, coverage unchanged at 92%.
- `pre-commit run --all-files` for the hooks that reach this diff (`ruff-check`,
  `ruff-format`, `mypy`, `vulture`, FawltyDeps, `vale`): all pass. The
  `renovate-config-validator` hook could not install its Node environment in this
  sandbox and touches nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LjKbxerFGqAP6862nLcmv