### PR TITLE
chore: add work-item issue form with a definition of done

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -7,8 +7,7 @@ body:
     attributes:
       value: >-
         Write the title as a statement that is true once the issue is done, so
-        the tracker reads as a list of outcomes. Fill the fields below to carry
-        the motivation, the concrete scope, and the test for completion.
+        the tracker reads as a list of outcomes.
 
   - type: textarea
     id: summary
@@ -40,8 +39,8 @@ body:
     attributes:
       label: Acceptance criteria
       description: >-
-        List the conditions that hold when this is done. Write each as a task
-        a reviewer can check off.
+        List the conditions that hold when this is done, each as a task a
+        reviewer can check off.
       placeholder: |
         - [ ] Tests and pre-commit pass
     validations:

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -27,8 +27,6 @@ body:
       placeholder: >-
         daily.yml runs `mutmut run --max-children 1`, one mutant at a time,
         under a 120-minute cap.
-    validations:
-      required: true
 
   - type: textarea
     id: motivation
@@ -37,8 +35,6 @@ body:
       description: >-
         Explain what this unblocks or improves, for whom, and what changed to
         make it worth doing now.
-    validations:
-      required: true
 
   - type: textarea
     id: approach
@@ -57,8 +53,6 @@ body:
       placeholder: >-
         zfs/replicate/snapshot/send.py, .github/workflows/daily.yml,
         docs/reference/testing.md
-    validations:
-      required: true
 
   - type: textarea
     id: out-of-scope

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,6 +1,7 @@
 ---
 name: Work item
 description: Track planned development work with a definition of done.
+type: Task
 labels: [enhancement]
 body:
   - type: markdown
@@ -82,8 +83,9 @@ body:
     attributes:
       label: Related issues
       description: >-
-        List one issue per line, saying what each contributes rather than the
-        number alone.
+        Add a blocked-by relationship for anything this cannot ship without.
+        Use this field for what the relationship does not record: what each
+        issue contributes.
       placeholder: >-
         #679 settles the import alias, which has to land before a check for it
         can go on.

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -85,28 +85,6 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: commit-type
-    attributes:
-      label: Expected commit type
-      description: >-
-        The pull request title carries this type, CI checks it, and
-        release-please reads it for the version bump. See the commit-messages
-        section of CONTRIBUTING.md.
-      options:
-        - "feat (minor bump): new user-visible capability"
-        - "fix (patch bump): bug fix"
-        - "perf (patch bump): performance improvement, no functional change"
-        - "refactor (no release): internal change, no behaviour change"
-        - "docs (no release): documentation only"
-        - "test (no release): adding or fixing tests"
-        - "build (no release): build system, packaging, or dependencies"
-        - "ci (no release): CI configuration"
-        - "chore (no release): maintenance with no source impact"
-        - "Not sure yet"
-    validations:
-      required: true
-
   - type: textarea
     id: related-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -18,21 +18,57 @@ body:
       required: true
 
   - type: textarea
+    id: current-behaviour
+    attributes:
+      label: Current behaviour
+      description: >-
+        Describe what the tree does today, naming the files, jobs, or commands
+        as they stand at HEAD. An implementer starts by reading what you name
+        here.
+      placeholder: >-
+        daily.yml runs `mutmut run --max-children 1`, one mutant at a time,
+        under a 120-minute cap.
+    validations:
+      required: true
+
+  - type: textarea
     id: motivation
     attributes:
       label: Motivation
-      description: Explain what this unblocks or improves, and for whom.
+      description: >-
+        Explain what this unblocks or improves, for whom, and what changed to
+        make it worth doing now.
     validations:
       required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Approach and alternatives
+      description: >-
+        Describe the approach you have in mind and the ones you set aside.
+        Where a claim is about speed or size, give the numbers and say where
+        they came from.
 
   - type: textarea
     id: scope
     attributes:
       label: Scope
-      description: Name the modules, commands, and documents the change touches.
-      placeholder: zfs/replicate/snapshot/send.py, zfs/replicate/cli/options.py
+      description: Name the modules, workflows, and documents the change touches.
+      placeholder: >-
+        zfs/replicate/snapshot/send.py, .github/workflows/daily.yml,
+        docs/reference/testing.md
     validations:
       required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: >-
+        Name what this deliberately leaves out, and the issue that carries it
+        if one does. A pull request keeps to one concern, so the boundary is
+        worth stating before the work starts.
 
   - type: textarea
     id: acceptance-criteria
@@ -40,14 +76,44 @@ body:
       label: Acceptance criteria
       description: >-
         List the conditions that hold when this is done, each as a task a
-        reviewer can check off.
+        reviewer can check off. Cover the outcome where the work proves not
+        worth doing.
       placeholder: |
         - [ ] Tests and pre-commit pass
+        - [ ] If the measurement says otherwise, this closes with the numbers
+              recorded, so the next person does not re-derive them
+    validations:
+      required: true
+
+  - type: dropdown
+    id: commit-type
+    attributes:
+      label: Expected commit type
+      description: >-
+        The pull request title carries this type, CI checks it, and
+        release-please reads it for the version bump. See the commit-messages
+        section of CONTRIBUTING.md.
+      options:
+        - "feat (minor bump): new user-visible capability"
+        - "fix (patch bump): bug fix"
+        - "perf (patch bump): performance improvement, no functional change"
+        - "refactor (no release): internal change, no behaviour change"
+        - "docs (no release): documentation only"
+        - "test (no release): adding or fixing tests"
+        - "build (no release): build system, packaging, or dependencies"
+        - "ci (no release): CI configuration"
+        - "chore (no release): maintenance with no source impact"
+        - "Not sure yet"
     validations:
       required: true
 
   - type: textarea
-    id: additional-context
+    id: related-issues
     attributes:
-      label: Additional context
-      description: Link related issues, prior discussion, or upstream references.
+      label: Related issues
+      description: >-
+        List one issue per line, saying what each contributes rather than the
+        number alone.
+      placeholder: >-
+        #679 settles the import alias, which has to land before a check for it
+        can go on.

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,54 @@
+---
+name: Work item
+description: Track planned development work with a definition of done.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Write the title as a statement that is true once the issue is done, so
+        the tracker reads as a list of outcomes. Fill the fields below to carry
+        the motivation, the concrete scope, and the test for completion.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: State the change in a sentence or two.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Explain what this unblocks or improves, and for whom.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Name the modules, commands, and documents the change touches.
+      placeholder: zfs/replicate/snapshot/send.py, zfs/replicate/cli/options.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: >-
+        List the conditions that hold when this is done. Write each as a task
+        a reviewer can check off.
+      value: |
+        - [ ] Tests and pre-commit pass
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Link related issues, prior discussion, or upstream references.

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -42,7 +42,7 @@ body:
       description: >-
         List the conditions that hold when this is done. Write each as a task
         a reviewer can check off.
-      value: |
+      placeholder: |
         - [ ] Tests and pre-commit pass
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -23,8 +23,7 @@ body:
       label: Current behaviour
       description: >-
         Describe what the tree does today, naming the files, jobs, or commands
-        as they stand at HEAD. An implementer starts by reading what you name
-        here.
+        as they stand at HEAD.
       placeholder: >-
         daily.yml runs `mutmut run --max-children 1`, one mutant at a time,
         under a 120-minute cap.
@@ -67,8 +66,8 @@ body:
       label: Out of scope
       description: >-
         Name what this deliberately leaves out, and the issue that carries it
-        if one does. A pull request keeps to one concern, so the boundary is
-        worth stating before the work starts.
+        if one does. A pull request keeps to one concern, so the boundary
+        belongs here.
 
   - type: textarea
     id: acceptance-criteria
@@ -80,8 +79,7 @@ body:
         worth doing.
       placeholder: |
         - [ ] Tests and pre-commit pass
-        - [ ] If the measurement says otherwise, this closes with the numbers
-              recorded, so the next person does not re-derive them
+        - [ ] If the change proves not worth making, this closes with the numbers recorded
     validations:
       required: true
 


### PR DESCRIPTION
## Summary

A third issue form covers planned work, asking for what the tree does today by path, the numbers behind any speed or size claim, acceptance criteria including the outcome where the work proves not worth doing, and an out-of-scope boundary. The fields come from reading #688, #676, #680, and #495 rather than from a generic template.

Only Summary and Acceptance criteria gate, since planning is when a filer has the fewest answers. The chooser now reads feature request at one gate, work item at two, bug report at six.

Closes #495

## Gotchas

- Three deviations from #495's acceptance criteria: eight fields rather than six, two gates where it implies five, and `placeholder` rather than `value` for the acceptance-criteria baseline, because GitHub counts a prefilled `value` as satisfying `required: true`.
- `type: Task` makes this the only form that classifies its output. The repository's three issue types have gone unused since 2026-08-19, and #692 tracks the siblings and the `enhancement` label question.
- It overlaps `feature-request.yml` more than the field names admit, and #691 tracks reconciling the two vocabularies. No sibling form changes here.

## Test plan

- Confirmed `type` is a documented top-level Issue Forms key and that Task resolves for this repository through the issue-types API.
- Parsed all three forms and compared gates: bug report 7 fields and 6, feature request 4 and 1, work item 8 and 2.
- Not verified: GitHub validates the schema and renders the form only on the default branch, so neither the render nor the type assignment is confirmed until merge.
