### PR TITLE
ci: run the suite against the built sdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,9 +142,12 @@ jobs:
           sdist="${archives[0]}"
           packaged_tests="${RUNNER_TEMP}/packaged-tests"
 
-          poetry install --only test --no-root
+          poetry install --only main,test --no-root
           venv="$(poetry env info --path)"
-          "${venv}/bin/pip" install "${sdist}"
+          # The groups above already hold poetry.lock's pins, and --no-deps
+          # leaves them there, so an upstream release inside the declared
+          # bounds cannot redden this job on its own.
+          "${venv}/bin/pip" install --no-deps "${sdist}"
 
           # Extracting only the tests keeps the packaged sources out of the
           # way, so `import zfs` resolves to the installed distribution.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,12 +130,30 @@ jobs:
         with:
           python-version: "3.12"
       - name: poetry build
-        run: |
-          poetry build
-          tar -zvtf dist/zfs_replicate-*.tar.gz | grep zfs/replicate/
-          tar -zvtf dist/zfs_replicate-*.tar.gz | grep zfs_test/replicate_test/
+        run: poetry build
       - name: poetry check
         run: poetry check
+      # Catches a module or test file missing from `packages`: the suite runs
+      # against what the sdist ships, not the checkout.
+      - name: test the built sdist
+        run: |
+          # CI builds into an empty dist/, so the glob matches one archive.
+          archives=(dist/zfs_replicate-*.tar.gz)
+          sdist="${archives[0]}"
+          packaged_tests="${RUNNER_TEMP}/packaged-tests"
+
+          poetry install --only test --no-root
+          venv="$(poetry env info --path)"
+          "${venv}/bin/pip" install "${sdist}"
+
+          # Extracting only the tests keeps the packaged sources out of the
+          # way, so `import zfs` resolves to the installed distribution.
+          mkdir --parents "${packaged_tests}"
+          tar --extract --gzip --file "${sdist}" --directory "${packaged_tests}" \
+            --strip-components=1 --wildcards '*/zfs_test/*' '*/pyproject.toml'
+
+          cd "${packaged_tests}"
+          "${venv}/bin/pytest"
 
   # Squash-merge lands the PR title as the commit message, so the title, not the
   # individual commits, is what release-please parses for version bumps. Keep


### PR DESCRIPTION
## Summary

The `build` job installs the sdist and runs the packaged suite against it, so a
distribution that ships sources it cannot import, or tests it cannot run, now
fails CI. It previously grepped the tarball for two paths and never ran what it
shipped. Closes #498.

## Gotchas

- The issue's sketch, `pytest --pyargs zfs_test`, cannot work: `packages` marks
  `zfs_test` as `format = "sdist"`, so pip never installs it. The tests come out
  of the tarball instead, and only `zfs_test` and `pyproject.toml` do;
  extracting `zfs/` beside them would shadow the installed distribution and test
  the checkout again.
- What catches a path dropped from `packages` is `tar --wildcards` exiting
  non-zero on a pattern that matches nothing, not an assertion in the suite.
- Watch the `--no-root` on `poetry install`. Without it Poetry installs the
  checkout into the same venv, and the tests import that rather than the sdist.
- The install is hermetic on purpose: `--only main,test` seeds `poetry.lock`'s
  pins and `--no-deps` stops pip resolving over them, so nobody else's release
  can redden this job. The declared bounds in `pyproject.toml` therefore still
  have no CI coverage. The one fetch left is pip's build isolation pulling
  `poetry-core` per the range in `[build-system]`.

## Test plan

- Ran the step end to end from a clean tree: 78 tests passed, with
  `zfs.replicate.stderr` resolving to `.venv/lib/.../site-packages`, not the
  worktree.
- Dropped `zfs_test` from `packages`, rebuilt, and confirmed `tar` exits 2.
- Removed a module from the installed distribution and confirmed the run fails
  with 25 collection errors.
- Pinned `click` to 8.2.1 in the venv, below what a live resolve would pick,
  and confirmed the `--no-deps` install left it there and the suite still
  passed.
