### PR TITLE
refactor: adopt PEP 585 and PEP 604 annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,11 +98,9 @@ src = ["."]
 quote-style = "double"
 
 [tool.ruff.lint]
-# UP (pyupgrade) is intentionally omitted here: enabling it rewrites ~99 typing
-# annotations across the tree, deferred to keep this migration reviewable (#501).
 # PGH and RUF100 stand in for the removed pygrep-hooks and yesqa hooks; G010 for
 # python-no-log-warn; S (above) covers python-no-eval and the bandit rule set.
-select = ["E", "F", "I", "B", "SIM", "D", "N", "S", "G010", "PGH", "PL", "RUF100"]
+select = ["E", "F", "I", "B", "SIM", "D", "N", "S", "G010", "PGH", "PL", "RUF100", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests assert (S101) and compare against literal expectations (PLR2004) by design.

--- a/zfs/replicate/cli/log.py
+++ b/zfs/replicate/cli/log.py
@@ -11,7 +11,8 @@ module owns how that output is presented, which is the command line's concern.
 
 import logging
 import sys
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 import click_log
 

--- a/zfs/replicate/cli/options.py
+++ b/zfs/replicate/cli/options.py
@@ -1,7 +1,7 @@
 """Command-line option groups."""
 
 import functools
-from typing import Callable, Dict, Tuple
+from collections.abc import Callable
 
 import click
 
@@ -145,7 +145,7 @@ def receive_group(command: Callable[..., None]) -> Callable[..., None]:  # pragm
         receive_force: bool,
         receive_mount: bool,
         receive_resume: bool,
-        receive_set: Tuple[str, ...],
+        receive_set: tuple[str, ...],
         **kwargs: object,
     ) -> None:
         return command(
@@ -162,8 +162,8 @@ def receive_group(command: Callable[..., None]) -> Callable[..., None]:  # pragm
     return wrapper
 
 
-def _parse_properties(properties: Tuple[str, ...]) -> Dict[str, str]:
-    parsed: Dict[str, str] = {}
+def _parse_properties(properties: tuple[str, ...]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
 
     for item in properties:
         key, separator, value = item.partition("=")

--- a/zfs/replicate/command.py
+++ b/zfs/replicate/command.py
@@ -14,11 +14,11 @@ hand-placed quotes.
 """
 
 import shlex
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import List, Mapping, Optional, Tuple
 
 # Prefix that empties the environment before exec, kept in one place.
-ENV: Tuple[str, str] = ("/usr/bin/env", "-")
+ENV: tuple[str, str] = ("/usr/bin/env", "-")
 
 
 @dataclass(frozen=True)
@@ -33,8 +33,8 @@ class Command:
     """
 
     program: str
-    args: List[str] = field(default_factory=list)
-    env: Optional[Mapping[str, str]] = None
+    args: list[str] = field(default_factory=list)
+    env: Mapping[str, str] | None = None
 
     @classmethod
     def with_empty_env(cls, program: str, *args: str) -> "Command":
@@ -49,7 +49,7 @@ class Command:
         return cls(program=ENV[0], args=[ENV[1], program, *args])
 
     @property
-    def argv(self) -> List[str]:
+    def argv(self) -> list[str]:
         """The command as one list, the form the exec layer and ``render`` consume."""
         return [self.program, *self.args]
 

--- a/zfs/replicate/compress/command.py
+++ b/zfs/replicate/compress/command.py
@@ -1,7 +1,6 @@
 """ZFS Replication Compression Command Mapping."""
 
 from dataclasses import dataclass
-from typing import Optional
 
 from ..command import Command
 from .type import Compression
@@ -20,7 +19,7 @@ class Commands:
     decompress: Command
 
 
-def command(compression: Compression) -> Optional[Commands]:
+def command(compression: Compression) -> Commands | None:
     """Map a compression to its local compress and remote decompress commands.
 
     ``OFF`` yields ``None`` -- no compression stage.

--- a/zfs/replicate/filesystem/create.py
+++ b/zfs/replicate/filesystem/create.py
@@ -8,7 +8,7 @@ from ..error import ZFSReplicateError
 from ..list import inits
 from ..stderr import clean
 from . import type
-from .list import list
+from .list import list_filesystems
 from .type import FileSystem
 
 
@@ -19,7 +19,7 @@ def create(filesystem: FileSystem, ssh_command: Command) -> None:
 
     top_level = type.filesystem(name=filesystem.dataset, readonly=filesystem.readonly)
 
-    filesystems = [x.name for x in list(top_level, ssh_command=ssh_command)]
+    filesystems = [x.name for x in list_filesystems(top_level, ssh_command=ssh_command)]
 
     for head in inits(filesystem.name.split("/"))[1:]:
         path = os.path.join(*head)

--- a/zfs/replicate/filesystem/list.py
+++ b/zfs/replicate/filesystem/list.py
@@ -1,7 +1,7 @@
 """ZFs FileSystem List."""
 
+import builtins
 import re
-from typing import List
 
 from .. import process
 from ..command import Command, over_ssh
@@ -13,7 +13,7 @@ from .type import FileSystem
 RE_WHITESPACE = re.compile(b"[ \t]+")
 
 
-def list(filesystem: FileSystem, ssh_command: Command) -> List[FileSystem]:
+def list(filesystem: FileSystem, ssh_command: Command) -> builtins.list[FileSystem]:
     """List ZFS FileSystem on the remote reachable through ``ssh_command``."""
     result = process.run(over_ssh(ssh_command, _list(filesystem)))
 
@@ -35,7 +35,7 @@ def _list(filesystem: FileSystem) -> Command:
     return Command.with_empty_env("zfs", "list", *options, filesystem.name)
 
 
-def _filesystems(zfs_list_output: bytes) -> List[FileSystem]:
+def _filesystems(zfs_list_output: bytes) -> builtins.list[FileSystem]:
     return [_filesystem(x) for x in zfs_list_output.split(b"\n") if x != b""]
 
 

--- a/zfs/replicate/filesystem/list.py
+++ b/zfs/replicate/filesystem/list.py
@@ -1,6 +1,5 @@
 """ZFs FileSystem List."""
 
-import builtins
 import re
 
 from .. import process
@@ -13,7 +12,7 @@ from .type import FileSystem
 RE_WHITESPACE = re.compile(b"[ \t]+")
 
 
-def list(filesystem: FileSystem, ssh_command: Command) -> builtins.list[FileSystem]:
+def list_filesystems(filesystem: FileSystem, ssh_command: Command) -> list[FileSystem]:
     """List ZFS FileSystem on the remote reachable through ``ssh_command``."""
     result = process.run(over_ssh(ssh_command, _list(filesystem)))
 
@@ -35,7 +34,7 @@ def _list(filesystem: FileSystem) -> Command:
     return Command.with_empty_env("zfs", "list", *options, filesystem.name)
 
 
-def _filesystems(zfs_list_output: bytes) -> builtins.list[FileSystem]:
+def _filesystems(zfs_list_output: bytes) -> list[FileSystem]:
     return [_filesystem(x) for x in zfs_list_output.split(b"\n") if x != b""]
 
 

--- a/zfs/replicate/list.py
+++ b/zfs/replicate/list.py
@@ -1,6 +1,7 @@
 """Common List Functions."""
 
-from typing import List, Sequence, Tuple, TypeVar
+from collections.abc import Sequence
+from typing import TypeVar
 
 __all__ = ("inits", "venn")
 
@@ -19,9 +20,9 @@ def inits(elements: Sequence[T]) -> Sequence[Sequence[T]]:
 
 
 def venn(
-    lefts: List[T],
-    rights: List[T],
-) -> Tuple[List[T], List[T], List[T]]:
+    lefts: list[T],
+    rights: list[T],
+) -> tuple[list[T], list[T], list[T]]:
     """Calculate venn diagram of the two sequences.
 
     A venn diagram shows the elements both sets contain individually as

--- a/zfs/replicate/optional.py
+++ b/zfs/replicate/optional.py
@@ -1,11 +1,11 @@
 """Optional Functions."""
 
-from typing import List, Optional, TypeVar
+from typing import TypeVar
 
 Value = TypeVar("Value")
 
 
-def value(optional: Optional[Value]) -> Value:
+def value(optional: Value | None) -> Value:
     """Raise error if optional is None."""
     if optional is None:
         raise RuntimeError("unexpected None")
@@ -13,7 +13,7 @@ def value(optional: Optional[Value]) -> Value:
     return optional
 
 
-def values(*optionals: Optional[Value]) -> List[Value]:
+def values(*optionals: Value | None) -> list[Value]:
     """Keep the values that are present, in the order given.
 
     >>> values(1, None, 3)

--- a/zfs/replicate/process.py
+++ b/zfs/replicate/process.py
@@ -7,7 +7,7 @@ shell-free guarantee lives here and nowhere else.
 """
 
 import subprocess
-from typing import IO, Optional, Union
+from typing import IO
 
 from .command import Command
 
@@ -18,7 +18,7 @@ Popen = subprocess.Popen
 
 # None means "inherit the parent's stream"; an int is a file descriptor or one
 # of PIPE/DEVNULL/STDOUT; an IO wires one process's stream to another's.
-Stream = Optional[Union[IO[bytes], int]]
+Stream = IO[bytes] | int | None
 
 
 def open(
@@ -74,7 +74,7 @@ def run(
     return subprocess.CompletedProcess(command.argv, proc.returncode, output, error)
 
 
-def _detach(stream: Optional[IO[bytes]]) -> None:
+def _detach(stream: IO[bytes] | None) -> None:
     """Drop the parent's copy of a piped stream so its reader sees EOF/SIGPIPE."""
     if stream is not None:
         stream.close()

--- a/zfs/replicate/receive/type.py
+++ b/zfs/replicate/receive/type.py
@@ -1,7 +1,7 @@
 """ZFS Receive Type."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import List, Mapping
 
 
 @dataclass(frozen=True)
@@ -17,7 +17,7 @@ class Options:
     resume: bool = False
     properties: Mapping[str, str] = field(default_factory=dict)
 
-    def to_flags(self) -> List[str]:
+    def to_flags(self) -> list[str]:
         """Render these settings as ``zfs receive`` argv tokens (the caller adds ``-d``).
 
         Each ``-o`` property is two tokens (``"-o"`` then ``"key=value"``) so

--- a/zfs/replicate/send/type.py
+++ b/zfs/replicate/send/type.py
@@ -1,7 +1,6 @@
 """ZFS Send Type."""
 
 from dataclasses import dataclass
-from typing import List
 
 
 @dataclass(frozen=True)
@@ -33,7 +32,7 @@ class Options:
     compressed: bool = False
     props: bool = False
 
-    def to_flags(self) -> List[str]:
+    def to_flags(self) -> list[str]:
         """Return the enabled options as ``zfs send`` tokens, e.g. ``["-L", "-w"]``.
 
         Emits flags in a stable ``-L -w -e -c -p`` order and omits the

--- a/zfs/replicate/snapshot/__init__.py
+++ b/zfs/replicate/snapshot/__init__.py
@@ -5,8 +5,6 @@ from .list import list_snapshots as list
 from .send import send
 from .type import Snapshot
 
-# ``list`` is the public spelling of ``list_snapshots``, which is named to avoid
-# shadowing the builtin inside its own module. A re-export under a different name
-# cannot use the redundant-alias form that marks the others public, so the whole
-# surface is declared here instead.
+# The definition is ``list_snapshots`` so it does not shadow the builtin inside
+# its own module.
 __all__ = ("Snapshot", "destroy", "list", "send")

--- a/zfs/replicate/snapshot/__init__.py
+++ b/zfs/replicate/snapshot/__init__.py
@@ -1,6 +1,12 @@
 """ZFS Snapshot Operations."""
 
-from .destroy import destroy as destroy
-from .list import list as list
-from .send import send as send
-from .type import Snapshot as Snapshot
+from .destroy import destroy
+from .list import list_snapshots as list
+from .send import send
+from .type import Snapshot
+
+# ``list`` is the public spelling of ``list_snapshots``, which is named to avoid
+# shadowing the builtin inside its own module. A re-export under a different name
+# cannot use the redundant-alias form that marks the others public, so the whole
+# surface is declared here instead.
+__all__ = ("Snapshot", "destroy", "list", "send")

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -1,6 +1,6 @@
 """ZFS Snapshot listing."""
 
-from typing import List, Optional
+import builtins
 
 from .. import process
 from ..command import Command, over_ssh
@@ -13,8 +13,8 @@ from .type import Snapshot
 def list(
     filesystem: FileSystem,
     recursive: bool,
-    ssh_command: Optional[Command] = None,
-) -> List[Snapshot]:
+    ssh_command: Command | None = None,
+) -> builtins.list[Snapshot]:
     """List ZFS snapshots."""
     command = _list(filesystem, recursive)
     if ssh_command is not None:
@@ -44,7 +44,7 @@ def _list(filesystem: FileSystem, recursive: bool) -> Command:
     return Command.with_empty_env("zfs", "list", *options, filesystem.name)
 
 
-def _snapshots(zfs_list_output: bytes) -> List[Snapshot]:
+def _snapshots(zfs_list_output: bytes) -> builtins.list[Snapshot]:
     snapshots = [_snapshot(x) for x in zfs_list_output.split(b"\n") if x != b""]
 
     if not snapshots:
@@ -69,7 +69,7 @@ def _snapshot(zfs_list_line: bytes) -> Snapshot:
     )
 
 
-def _add_previous(snapshot: Snapshot, previous: Optional[Snapshot] = None) -> Snapshot:
+def _add_previous(snapshot: Snapshot, previous: Snapshot | None = None) -> Snapshot:
     if previous is not None and snapshot.filesystem != previous.filesystem:
         previous = None
 

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -1,7 +1,5 @@
 """ZFS Snapshot listing."""
 
-import builtins
-
 from .. import process
 from ..command import Command, over_ssh
 from ..error import ZFSReplicateError
@@ -10,11 +8,11 @@ from ..stderr import clean
 from .type import Snapshot
 
 
-def list(
+def list_snapshots(
     filesystem: FileSystem,
     recursive: bool,
     ssh_command: Command | None = None,
-) -> builtins.list[Snapshot]:
+) -> list[Snapshot]:
     """List ZFS snapshots."""
     command = _list(filesystem, recursive)
     if ssh_command is not None:
@@ -44,7 +42,7 @@ def _list(filesystem: FileSystem, recursive: bool) -> Command:
     return Command.with_empty_env("zfs", "list", *options, filesystem.name)
 
 
-def _snapshots(zfs_list_output: bytes) -> builtins.list[Snapshot]:
+def _snapshots(zfs_list_output: bytes) -> list[Snapshot]:
     snapshots = [_snapshot(x) for x in zfs_list_output.split(b"\n") if x != b""]
 
     if not snapshots:

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -13,7 +13,10 @@ def list_snapshots(
     recursive: bool,
     ssh_command: Command | None = None,
 ) -> list[Snapshot]:
-    """List ZFS snapshots."""
+    """List ZFS snapshots, each chained to its predecessor in the same filesystem.
+
+    The ``previous`` link is what a later send turns into ``zfs send -i``.
+    """
     command = _list(filesystem, recursive)
     if ssh_command is not None:
         command = over_ssh(ssh_command, command)

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -1,7 +1,6 @@
 """ZFS Snapshot Send."""
 
 from dataclasses import dataclass
-from typing import List, Optional
 
 from .. import compress, filesystem, optional, process, receive
 from ..command import Command, over_ssh
@@ -24,11 +23,11 @@ class Pipeline:
     """
 
     send: Command
-    compress: Optional[Command]
+    compress: Command | None
     receive: Command
 
     @property
-    def stages(self) -> List[Command]:
+    def stages(self) -> list[Command]:
         """The commands to run, in pipeline order."""
         return optional.values(self.send, self.compress, self.receive)
 
@@ -41,7 +40,7 @@ def send(  # noqa: PLR0913 -- carries the full replication call surface
     compression: Compression,
     send_options: SendOptions,
     receive_options: receive.Options,
-    previous: Optional[Snapshot] = None,
+    previous: Snapshot | None = None,
 ) -> None:
     """Send ZFS Snapshot."""
     pipeline = _pipeline(
@@ -69,7 +68,7 @@ def _pipeline(  # noqa: PLR0913 -- carries the full replication call surface
     compression: Compression,
     send_options: SendOptions,
     receive_options: receive.Options,
-    previous: Optional[Snapshot] = None,
+    previous: Snapshot | None = None,
 ) -> Pipeline:
     """Assemble the pipeline that replicates ``current`` onto ``remote``, spawning nothing."""
     send_command = _send(current, previous, options=send_options)
@@ -102,7 +101,7 @@ def _raise_for_failure(current: Snapshot, returncode: int, error: bytes) -> None
 
 def _send(
     current: Snapshot,
-    previous: Optional[Snapshot] = None,
+    previous: Snapshot | None = None,
     *,
     options: SendOptions,
 ) -> Command:

--- a/zfs/replicate/ssh/command.py
+++ b/zfs/replicate/ssh/command.py
@@ -1,14 +1,12 @@
 """SSH Command Generator."""
 
-from typing import List
-
 from ..command import Command
 from .cipher import Cipher
 
 
 def command(cipher: Cipher, user: str, key_file: str, port: int, host: str) -> Command:
     """Generate ssh commandline invocation."""
-    options: List[str] = []
+    options: list[str] = []
 
     if cipher == Cipher.FAST:
         options.extend(

--- a/zfs/replicate/task/execute.py
+++ b/zfs/replicate/task/execute.py
@@ -2,7 +2,6 @@
 
 import itertools
 import logging
-from typing import List, Tuple
 
 from .. import filesystem, optional, receive, send, snapshot
 from ..command import Command
@@ -15,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def execute(  # noqa: PLR0913 -- carries the full replication call surface
     remote: FileSystem,
-    tasks: List[Tuple[FileSystem, List[Task]]],
+    tasks: list[tuple[FileSystem, list[Task]]],
     *,
     ssh_command: Command,
     compression: Compression,
@@ -47,13 +46,13 @@ def execute(  # noqa: PLR0913 -- carries the full replication call surface
                 )
 
 
-def _create(tasks: List[Task], ssh_command: Command) -> None:
+def _create(tasks: list[Task], ssh_command: Command) -> None:
     for task in tasks:
         logger.info("creating filesystem %s", task.filesystem.name)
         filesystem.create(task.filesystem, ssh_command=ssh_command)
 
 
-def _destroy(tasks: List[Task], ssh_command: Command) -> None:
+def _destroy(tasks: list[Task], ssh_command: Command) -> None:
     for task in tasks:
         if task.snapshot is None:
             logger.info("destroying filesystem %s", task.filesystem.name)
@@ -69,7 +68,7 @@ def _destroy(tasks: List[Task], ssh_command: Command) -> None:
 
 def _send(  # noqa: PLR0913 -- carries the full replication call surface
     remote: FileSystem,
-    tasks: List[Task],
+    tasks: list[Task],
     *,
     ssh_command: Command,
     compression: Compression,

--- a/zfs/replicate/task/generate.py
+++ b/zfs/replicate/task/generate.py
@@ -1,6 +1,6 @@
 """Replication Tasks."""
 
-from typing import Dict, Iterable, List
+from collections.abc import Iterable
 
 from ..filesystem import FileSystem, remote_filesystem
 from ..list import venn
@@ -8,20 +8,20 @@ from ..snapshot import Snapshot
 from .type import Action, Task
 
 
-def _destroy_snapshots(destination: FileSystem, snapshots: Iterable[Snapshot]) -> List[Task]:
+def _destroy_snapshots(destination: FileSystem, snapshots: Iterable[Snapshot]) -> list[Task]:
     return [Task(action=Action.DESTROY, filesystem=destination, snapshot=s) for s in snapshots]
 
 
-def _send_snapshots(remote: FileSystem, snapshots: Iterable[Snapshot]) -> List[Task]:
+def _send_snapshots(remote: FileSystem, snapshots: Iterable[Snapshot]) -> list[Task]:
     return [Task(action=Action.SEND, filesystem=remote, snapshot=s) for s in snapshots]
 
 
 def generate(
     remote: FileSystem,
-    local_snapshots: Dict[FileSystem, List[Snapshot]],
-    remote_snapshots: Dict[FileSystem, List[Snapshot]],
+    local_snapshots: dict[FileSystem, list[Snapshot]],
+    remote_snapshots: dict[FileSystem, list[Snapshot]],
     follow_delete: bool = False,
-) -> List[Task]:
+) -> list[Task]:
     """Generate Tasks for replicating local snapshots to remote snapshots."""
     tasks = []
 

--- a/zfs/replicate/task/report.py
+++ b/zfs/replicate/task/report.py
@@ -1,7 +1,6 @@
 """Task Reporting Functions."""
 
 import itertools
-from typing import List, Tuple
 
 from ..filesystem import FileSystem
 from ..snapshot import Snapshot
@@ -12,7 +11,7 @@ LIMITS = {"filesystem": 6, "action": 4, "snapshot": 13}
 AFTERS = {"filesystem": "action", "action": "snapshot"}
 
 
-def report(tasks: List[Task]) -> str:
+def report(tasks: list[Task]) -> str:
     """Pretty printed report on given Tasks."""
     filesystems = [
         (filesystem, list(tasks)) for filesystem, tasks in itertools.groupby(tasks, key=lambda x: x.filesystem)
@@ -24,7 +23,7 @@ def report(tasks: List[Task]) -> str:
     return _report_filesystem(filesystems)
 
 
-def _report_filesystem(filesystems: List[Tuple[FileSystem, List[Task]]]) -> str:
+def _report_filesystem(filesystems: list[tuple[FileSystem, list[Task]]]) -> str:
     output = ""
 
     for filesystem, tasks in filesystems:
@@ -40,7 +39,7 @@ def _report_filesystem(filesystems: List[Tuple[FileSystem, List[Task]]]) -> str:
     return output
 
 
-def _report_action(actions: List[Tuple[Action, List[Task]]], indentation: str = "") -> str:
+def _report_action(actions: list[tuple[Action, list[Task]]], indentation: str = "") -> str:
     output = ""
 
     for action, tasks in actions:
@@ -60,7 +59,7 @@ def _report_action(actions: List[Tuple[Action, List[Task]]], indentation: str = 
     return output
 
 
-def _report_snapshot(snapshots: List[Tuple[Snapshot, List[Task]]], indentation: str = "") -> str:
+def _report_snapshot(snapshots: list[tuple[Snapshot, list[Task]]], indentation: str = "") -> str:
     output = "\n".join([f"{indentation}snapshot: {s.filesystem.name}@{s.name}" for s, _ in snapshots])
 
     if output:
@@ -69,7 +68,7 @@ def _report_snapshot(snapshots: List[Tuple[Snapshot, List[Task]]], indentation: 
     return output
 
 
-def _counts(current: str, tasks: List[Task], indentation: str = "") -> str:
+def _counts(current: str, tasks: list[Task], indentation: str = "") -> str:
     group = {getattr(x, current) for x in tasks}
 
     output = f"{indentation}{current}:{len(group)}\n"

--- a/zfs/replicate/task/type.py
+++ b/zfs/replicate/task/type.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Optional
 
 from ..filesystem import FileSystem
 from ..snapshot import Snapshot
@@ -22,4 +21,4 @@ class Task:
 
     action: Action
     filesystem: FileSystem
-    snapshot: Optional[Snapshot]
+    snapshot: Snapshot | None

--- a/zfs_test/conftest.py
+++ b/zfs_test/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import subprocess
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from hypothesis import HealthCheck, settings

--- a/zfs_test/replicate_test/cli_test/main_test.py
+++ b/zfs_test/replicate_test/cli_test/main_test.py
@@ -1,6 +1,6 @@
 """zfs.replicate.cli.main tests."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from click.testing import CliRunner, Result

--- a/zfs_test/replicate_test/filesystem_test/destroy_test.py
+++ b/zfs_test/replicate_test/filesystem_test/destroy_test.py
@@ -1,6 +1,6 @@
 """zfs.replicate.filesystem.destroy tests."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 

--- a/zfs_test/replicate_test/list_test.py
+++ b/zfs_test/replicate_test/list_test.py
@@ -1,7 +1,5 @@
 """Tests for zfs.replicate.list."""
 
-from typing import List, Set
-
 from hypothesis import given
 from hypothesis.strategies import integers, lists, sets
 
@@ -12,18 +10,18 @@ class TestInits:
     """Every prefix appears once, in increasing length."""
 
     @given(lists(integers()))
-    def test_length(self, elements: List[int]) -> None:
+    def test_length(self, elements: list[int]) -> None:
         """len(inits(elements)) == len(elements) + 1."""
         assert len(sut.inits(elements)) == len(elements) + 1
 
     @given(lists(integers(), min_size=2))
-    def test_heads(self, elements: List[int]) -> None:
+    def test_heads(self, elements: list[int]) -> None:
         """inits(elements)[:1] == [[], [elements[0]]."""
         assert sut.inits(elements)[0] == []
         assert sut.inits(elements)[1] == [elements[0]]
 
     @given(lists(integers()))
-    def test_monotonic_length(self, elements: List[int]) -> None:
+    def test_monotonic_length(self, elements: list[int]) -> None:
         """[len(x) for xs in inits(elements)] == range(len(elements) + 1)."""
         lengths = [len(xs) for xs in sut.inits(elements)]
 
@@ -34,7 +32,7 @@ class TestVenn:
     """Each element lands in exactly one of the three parts."""
 
     @given(sets(integers()), sets(integers()))
-    def test_subsets(self, lefts: Set[int], rights: Set[int]) -> None:
+    def test_subsets(self, lefts: set[int], rights: set[int]) -> None:
         """All combinations of venn with subsets."""
         r_lefts, r_middles, r_rights = sut.venn(list(lefts), list(lefts | rights))
 
@@ -53,7 +51,7 @@ class TestVenn:
         )
 
     @given(lists(integers()))
-    def test_disjoint(self, both: List[int]) -> None:
+    def test_disjoint(self, both: list[int]) -> None:
         """Venn with disjoint."""
         e_lefts = list(filter(lambda x: x % 2 == 0, both))
         e_rights = list(filter(lambda x: x % 2 != 0, both))

--- a/zfs_test/replicate_test/optional_test.py
+++ b/zfs_test/replicate_test/optional_test.py
@@ -1,7 +1,5 @@
 """Tests for zfs.replicate.optional."""
 
-from typing import List, Optional
-
 import pytest
 from hypothesis import given
 from hypothesis.strategies import integers, lists, none, one_of
@@ -27,7 +25,7 @@ class TestValues:
     """Nothing missing survives, and everything present keeps its order."""
 
     @given(lists(one_of(integers(), none())))
-    def test_drops_every_none(self, elements: List[Optional[int]]) -> None:
+    def test_drops_every_none(self, elements: list[int | None]) -> None:
         """No None survives, and a second pass has nothing left to drop."""
         kept = optional.values(*elements)
 
@@ -35,6 +33,6 @@ class TestValues:
         assert optional.values(*kept) == kept
 
     @given(lists(integers()))
-    def test_keeps_present_values_in_order(self, elements: List[int]) -> None:
+    def test_keeps_present_values_in_order(self, elements: list[int]) -> None:
         """Nothing is missing, so everything comes back as it went in."""
         assert optional.values(*elements) == elements

--- a/zfs_test/replicate_test/snapshot_test/destroy_test.py
+++ b/zfs_test/replicate_test/snapshot_test/destroy_test.py
@@ -1,6 +1,6 @@
 """zfs.replicate.snapshot.destroy tests."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 

--- a/zfs_test/replicate_test/snapshot_test/list_test.py
+++ b/zfs_test/replicate_test/snapshot_test/list_test.py
@@ -1,7 +1,5 @@
 """zfs.replicate.snapshot tests."""
 
-from typing import List
-
 from hypothesis import given
 from hypothesis.strategies import lists
 
@@ -18,13 +16,13 @@ class TestList:
     """
 
     @given(lists(SNAPSHOTS))
-    def test_snapshots(self, snapshots: List[Snapshot]) -> None:
+    def test_snapshots(self, snapshots: list[Snapshot]) -> None:
         """_snapshots."""
         output = "\n".join([_output(s) for s in snapshots])
         assert _snapshots(output.encode()) == snapshots
 
     @given(lists(SNAPSHOTS, min_size=1))
-    def test_snapshots_depth(self, snapshots: List[Snapshot]) -> None:
+    def test_snapshots_depth(self, snapshots: list[Snapshot]) -> None:
         """Ensure max depth of 2."""
         output = "\n".join([_output(s) for s in snapshots])
         assert max(map(_depth, _snapshots(output.encode()))) <= 2

--- a/zfs_test/replicate_test/snapshot_test/send_test.py
+++ b/zfs_test/replicate_test/snapshot_test/send_test.py
@@ -1,6 +1,6 @@
 """zfs.replicate.snapshot.send tests."""
 
-from typing import Callable, List, Optional, Tuple
+from collections.abc import Callable
 
 import pytest
 from pytest_mock import MockerFixture
@@ -47,7 +47,7 @@ class _FakeProcess:
         self.stdout = _FakeStream()
         self._error = error
 
-    def communicate(self) -> Tuple[bytes, bytes]:
+    def communicate(self) -> tuple[bytes, bytes]:
         """Return the captured streams the real ``Popen`` would."""
         return (b"", self._error)
 
@@ -82,7 +82,7 @@ class TestSend:
             *,
             compression: Compression = Compression.OFF,
             receive_options: ReceiveOptions = RECEIVE_DEFAULTS,
-            previous: Optional[Snapshot] = None,
+            previous: Snapshot | None = None,
         ) -> Pipeline:
             return _pipeline(
                 remote,
@@ -118,11 +118,11 @@ class TestSend:
         return _replicate
 
     @pytest.fixture
-    def capture_spawns(self, mocker: MockerFixture) -> Callable[..., List[_FakeProcess]]:
+    def capture_spawns(self, mocker: MockerFixture) -> Callable[..., list[_FakeProcess]]:
         """Replace the process boundary and collect the processes it hands back."""
 
-        def _capture_spawns(returncode: int = 0, error: bytes = b"") -> List[_FakeProcess]:
-            spawned: List[_FakeProcess] = []
+        def _capture_spawns(returncode: int = 0, error: bytes = b"") -> list[_FakeProcess]:
+            spawned: list[_FakeProcess] = []
 
             def fake_open(command: Command, **_kwargs: object) -> _FakeProcess:
                 spawned.append(_FakeProcess(command, returncode, error))
@@ -204,7 +204,7 @@ class TestSend:
 
     def test_send_spawns_each_assembled_stage(
         self,
-        capture_spawns: Callable[..., List[_FakeProcess]],
+        capture_spawns: Callable[..., list[_FakeProcess]],
         replicate: Callable[..., None],
     ) -> None:
         """Each assembled stage runs as a process, in pipeline order."""
@@ -216,7 +216,7 @@ class TestSend:
 
     def test_send_detaches_the_parent_from_every_upstream_stage(
         self,
-        capture_spawns: Callable[..., List[_FakeProcess]],
+        capture_spawns: Callable[..., list[_FakeProcess]],
         replicate: Callable[..., None],
     ) -> None:
         """The parent closes every piped stdout but the last, whose output it reads."""
@@ -228,7 +228,7 @@ class TestSend:
 
     def test_send_ignores_a_missing_mountpoint(
         self,
-        capture_spawns: Callable[..., List[_FakeProcess]],
+        capture_spawns: Callable[..., list[_FakeProcess]],
         replicate: Callable[..., None],
     ) -> None:
         """Replication tolerates a failure to create the destination mountpoint."""
@@ -238,7 +238,7 @@ class TestSend:
 
     def test_send_raises_on_any_other_failure(
         self,
-        capture_spawns: Callable[..., List[_FakeProcess]],
+        capture_spawns: Callable[..., list[_FakeProcess]],
         replicate: Callable[..., None],
     ) -> None:
         """A failed pipeline surfaces its stderr as a ZFSReplicateError."""

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -1,7 +1,7 @@
 """Snapshot Hypothesis Strategies."""
 
 import string
-from typing import Any, Dict
+from typing import Any
 
 from hypothesis.strategies import (
     SearchStrategy,
@@ -24,7 +24,7 @@ def _non_empty_name(suffix: str) -> str:
 
 _FILESYSTEMS = text(_ROUND_TRIP_SAFE).map(_non_empty_name).map(filesystem)
 
-_SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
+_SNAPSHOTS_DICT: dict[str, SearchStrategy[Any]] = {
     "filesystem": _FILESYSTEMS,
     "name": text(_ROUND_TRIP_SAFE),
     "timestamp": integers(),

--- a/zfs_test/replicate_test/snapshot_test/strategies_test.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies_test.py
@@ -1,7 +1,5 @@
 """zfs_test.replicate_test.snapshot_test.strategies tests."""
 
-from typing import Set
-
 from hypothesis import given
 
 import zfs_test.replicate_test.snapshot_test.strategies as sut
@@ -16,8 +14,8 @@ class TestSnapshots:
         assert len(_drawn_filesystem_names()) > 1
 
 
-def _drawn_filesystem_names() -> Set[str]:
-    names: Set[str] = set()
+def _drawn_filesystem_names() -> set[str]:
+    names: set[str] = set()
 
     @given(sut.SNAPSHOTS)
     def collect(snapshot: Snapshot) -> None:

--- a/zfs_test/replicate_test/task_test/generate_test.py
+++ b/zfs_test/replicate_test/task_test/generate_test.py
@@ -2,7 +2,7 @@
 
 import itertools
 import operator
-from typing import Dict, Iterable, List
+from collections.abc import Iterable
 
 from hypothesis import given
 from hypothesis.strategies import lists
@@ -32,7 +32,7 @@ _STALE = _snapshot(_DESTINATION, "stale", 3)
 
 # A fixture cannot do this grouping: the value it groups is drawn per example
 # rather than resolved once.
-def _by_filesystem(snapshots: Iterable[Snapshot]) -> Dict[FileSystem, List[Snapshot]]:
+def _by_filesystem(snapshots: Iterable[Snapshot]) -> dict[FileSystem, list[Snapshot]]:
     return {
         k: list(v)
         for (k, v) in itertools.groupby(
@@ -50,7 +50,7 @@ class TestGenerate:
         assert not generate(filesystem("pool/filesystem"), {}, {})
 
     @given(lists(SNAPSHOTS))
-    def test_empty_remotes(self, snapshots: List[Snapshot]) -> None:
+    def test_empty_remotes(self, snapshots: list[Snapshot]) -> None:
         """Generate with empty remotes."""
         snapshots_by_fs = _by_filesystem(snapshots)
 
@@ -62,7 +62,7 @@ class TestGenerate:
         )
 
     @given(lists(SNAPSHOTS))
-    def test_empty_locals(self, snapshots: List[Snapshot]) -> None:
+    def test_empty_locals(self, snapshots: list[Snapshot]) -> None:
         """Generate with empty locals."""
         snapshots_by_fs = _by_filesystem(snapshots)
 
@@ -74,7 +74,7 @@ class TestGenerate:
         assert all(t.action == Action.DESTROY for t in result)
 
     @given(lists(SNAPSHOTS))
-    def test_empty_locals_remote_prefixed(self, snapshots: List[Snapshot]) -> None:
+    def test_empty_locals_remote_prefixed(self, snapshots: list[Snapshot]) -> None:
         """Generate with empty locals and prefixed remotes."""
         remote = filesystem("backup")
         snapshots_by_fs = {remote_filesystem(remote, k): v for (k, v) in _by_filesystem(snapshots).items()}

--- a/zfs_test/replicate_test/task_test/report_test.py
+++ b/zfs_test/replicate_test/task_test/report_test.py
@@ -1,7 +1,5 @@
 """zfs.replicate.task.report tests."""
 
-from typing import List
-
 from hypothesis import given
 from hypothesis.strategies import builds, lists
 
@@ -17,7 +15,7 @@ class TestReport:
         assert report([]) == ""
 
     @given(tasks=lists(builds(Task), min_size=1))
-    def test_nonempty_tasks(self, tasks: List[Task]) -> None:
+    def test_nonempty_tasks(self, tasks: list[Task]) -> None:
         """Ensure nonempty report from nonempty actions."""
         result = report(tasks)
         assert result != ""


### PR DESCRIPTION
## Summary

Annotations read as `list[Snapshot]` and `Command | None` rather than
`List[Snapshot]` and `Optional[Command]`, and ruff's `UP` group is selected so
they stay that way. #404 and #499 deferred these 131 rewrites here.

Two Fowler moves beyond the mechanical churn: **Remove Dead Code** on the
`typing` imports `UP035` orphaned, and **Change Function Declaration** on
`filesystem.list.list` and `snapshot.list.list`, which shadowed the builtin in
their own modules and forced `builtins.list` into four annotations. Declined:
**Replace Primitive with Object** on `venn`'s 3-tuple return, filed as #693, and
**Introduce Parameter Object** on the three `PLR0913` suppressions, where the
breadth is deliberate.

Closes #501

## Gotchas

- **PEP 604 rewrites are in scope, against what #501 says.** It was written
  against a 3.9 floor and calls `UP007`/`UP045` no-ops until the floor rises.
  #535 moved the floor to 3.10, so 16 of the findings are `Optional[X]` →
  `X | None`.
- **`snapshot.list` is unchanged for callers.** `snapshot/__init__.py`
  re-exports `list_snapshots` under the old name, and declares `__all__` because
  the redundant-alias form cannot mark a name re-exported under a different
  spelling.

## Test plan

- `pre-commit run --all-files` clean; `pytest` 78 passed on 3.10, the floor, and
  3.14, the newest CI leg.
- Confirmed `snapshot.list` still resolves after the rename and points at
  `list_snapshots`.
