### PR TITLE
fix: hash Snapshots on the fields equality compares

### DIFF
--- a/zfs/replicate/snapshot/type.py
+++ b/zfs/replicate/snapshot/type.py
@@ -1,7 +1,7 @@
 """ZFS Snapshot Type."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 from ..filesystem import FileSystem
 
@@ -23,18 +23,27 @@ class Snapshot:
         if not isinstance(other, Snapshot):
             raise NotImplementedError
 
-        left = self.filesystem.name
-        right = other.filesystem.name
-        is_suffix = left == right or left.endswith("/" + right) or right.endswith("/" + left)
-
-        return is_suffix and self.name == other.name and self.timestamp == other.timestamp
+        return _same_filesystem(self.filesystem, other.filesystem) and self._key() == other._key()
 
     def __hash__(self) -> int:
-        """Hash of a Snapshot.
+        """Hash of a Snapshot."""
+        return hash(self._key())
 
-        Keys on the fields __eq__ compares exactly.  The filesystem is left out
-        because equality accepts a suffix match, so equal Snapshots can carry
-        different filesystem names; previous is left out because equality
-        ignores it.
+    def _key(self) -> Tuple[str, int]:
+        """Fields two equal Snapshots agree on exactly.
+
+        Hashing what __eq__ compares exactly holds equal Snapshots to equal
+        hashes.  The filesystem stays out because equality accepts a suffix
+        match, so equal Snapshots can carry different filesystem names, and
+        previous stays out because equality ignores it.
         """
-        return hash((self.name, self.timestamp))
+        return self.name, self.timestamp
+
+
+def _same_filesystem(left: FileSystem, right: FileSystem) -> bool:
+    """Whether two filesystems hold the same dataset.
+
+    zfs list reports a remote filesystem under the destination's name, leaving
+    the local name a slash-aligned suffix of the remote one.
+    """
+    return left.name == right.name or left.name.endswith("/" + right.name) or right.name.endswith("/" + left.name)

--- a/zfs/replicate/snapshot/type.py
+++ b/zfs/replicate/snapshot/type.py
@@ -32,16 +32,14 @@ class Snapshot:
     def _key(self) -> Tuple[str, int]:
         """Fields two equal Snapshots agree on exactly.
 
-        Hashing what __eq__ compares exactly holds equal Snapshots to equal
-        hashes.  The filesystem stays out because equality accepts a suffix
-        match, so equal Snapshots can carry different filesystem names, and
-        previous stays out because equality ignores it.
+        The filesystem is absent because equality accepts a suffix match, so
+        equal Snapshots can carry different filesystem names.
         """
         return self.name, self.timestamp
 
 
 def _same_filesystem(left: FileSystem, right: FileSystem) -> bool:
-    """Whether two filesystems hold the same dataset.
+    """Whether the two name the same filesystem.
 
     zfs list reports a remote filesystem under the destination's name, leaving
     the local name a slash-aligned suffix of the remote one.

--- a/zfs/replicate/snapshot/type.py
+++ b/zfs/replicate/snapshot/type.py
@@ -7,7 +7,7 @@ from ..filesystem import FileSystem
 
 
 @dataclass(frozen=True)
-class Snapshot:  # noqa: PLW1641 -- frozen dataclass generates __hash__; ruff sees only the explicit __eq__
+class Snapshot:
     """ZFS Snapshot Type."""
 
     filesystem: FileSystem
@@ -28,3 +28,13 @@ class Snapshot:  # noqa: PLW1641 -- frozen dataclass generates __hash__; ruff se
         is_suffix = left == right or left.endswith("/" + right) or right.endswith("/" + left)
 
         return is_suffix and self.name == other.name and self.timestamp == other.timestamp
+
+    def __hash__(self) -> int:
+        """Hash of a Snapshot.
+
+        Keys on the fields __eq__ compares exactly.  The filesystem is left out
+        because equality accepts a suffix match, so equal Snapshots can carry
+        different filesystem names; previous is left out because equality
+        ignores it.
+        """
+        return hash((self.name, self.timestamp))

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -24,7 +24,9 @@ def _non_empty_name(suffix: str) -> str:
     return f"a{suffix}"
 
 
-_FILESYSTEMS = text(_ROUND_TRIP_SAFE).map(_non_empty_name).map(filesystem)
+_NAMES = text(_ROUND_TRIP_SAFE).map(_non_empty_name)
+
+_FILESYSTEMS = _NAMES.map(filesystem)
 
 _SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
     "filesystem": _FILESYSTEMS,
@@ -43,4 +45,4 @@ def _rebase(drawn: Tuple[Snapshot, str]) -> Tuple[Snapshot, Snapshot]:
 
 # A remote filesystem carries the destination's name ahead of the local one, which is the case
 # Snapshot equality spans.
-REBASED_SNAPSHOTS = tuples(SNAPSHOTS, text(_ROUND_TRIP_SAFE).map(_non_empty_name)).map(_rebase)
+REBASED_SNAPSHOTS = tuples(SNAPSHOTS, _NAMES).map(_rebase)

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -1,7 +1,8 @@
 """Snapshot Hypothesis Strategies."""
 
 import string
-from typing import Any, Dict
+from dataclasses import replace
+from typing import Any, Dict, Tuple
 
 from hypothesis.strategies import (
     SearchStrategy,
@@ -9,6 +10,7 @@ from hypothesis.strategies import (
     integers,
     none,
     text,
+    tuples,
 )
 
 from zfs.replicate.filesystem.type import filesystem
@@ -31,3 +33,14 @@ _SNAPSHOTS_DICT: Dict[str, SearchStrategy[Any]] = {
     "previous": none(),
 }
 SNAPSHOTS = fixed_dictionaries(_SNAPSHOTS_DICT).map(lambda kwargs: Snapshot(**kwargs))
+
+
+def _rebase(drawn: Tuple[Snapshot, str]) -> Tuple[Snapshot, Snapshot]:
+    snapshot, parent = drawn
+
+    return snapshot, replace(snapshot, filesystem=filesystem(f"{parent}/{snapshot.filesystem.name}"))
+
+
+# A remote filesystem carries the destination's name ahead of the local one, which is the case
+# Snapshot equality spans.
+REBASED_SNAPSHOTS = tuples(SNAPSHOTS, text(_ROUND_TRIP_SAFE).map(_non_empty_name)).map(_rebase)

--- a/zfs_test/replicate_test/snapshot_test/strategies.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies.py
@@ -43,6 +43,5 @@ def _rebase(drawn: Tuple[Snapshot, str]) -> Tuple[Snapshot, Snapshot]:
     return snapshot, replace(snapshot, filesystem=filesystem(f"{parent}/{snapshot.filesystem.name}"))
 
 
-# A remote filesystem carries the destination's name ahead of the local one, which is the case
-# Snapshot equality spans.
+# Pairs whose fields differ but which Snapshot equality treats as one.
 REBASED_SNAPSHOTS = tuples(SNAPSHOTS, _NAMES).map(_rebase)

--- a/zfs_test/replicate_test/snapshot_test/strategies_test.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies_test.py
@@ -17,11 +17,11 @@ class TestSnapshots:
 
 
 class TestRebasedSnapshots:
-    """Drawn pairs differ in filesystem name yet compare equal."""
+    """Drawn pairs stand in for a local snapshot and its remote counterpart."""
 
     @given(sut.REBASED_SNAPSHOTS)
     def test_rebased(self, rebased: Tuple[Snapshot, Snapshot]) -> None:
-        """REBASED_SNAPSHOTS draws pairs that equality spans and identity does not."""
+        """REBASED_SNAPSHOTS draws pairs with differing filesystems that compare equal."""
         local, remote = rebased
         assert local.filesystem != remote.filesystem
         assert local == remote

--- a/zfs_test/replicate_test/snapshot_test/strategies_test.py
+++ b/zfs_test/replicate_test/snapshot_test/strategies_test.py
@@ -1,6 +1,6 @@
 """zfs_test.replicate_test.snapshot_test.strategies tests."""
 
-from typing import Set
+from typing import Set, Tuple
 
 from hypothesis import given
 
@@ -14,6 +14,17 @@ class TestSnapshots:
     def test_vary_filesystem(self) -> None:
         """SNAPSHOTS draws more than one filesystem name."""
         assert len(_drawn_filesystem_names()) > 1
+
+
+class TestRebasedSnapshots:
+    """Drawn pairs differ in filesystem name yet compare equal."""
+
+    @given(sut.REBASED_SNAPSHOTS)
+    def test_rebased(self, rebased: Tuple[Snapshot, Snapshot]) -> None:
+        """REBASED_SNAPSHOTS draws pairs that equality spans and identity does not."""
+        local, remote = rebased
+        assert local.filesystem != remote.filesystem
+        assert local == remote
 
 
 def _drawn_filesystem_names() -> Set[str]:

--- a/zfs_test/replicate_test/snapshot_test/type_test.py
+++ b/zfs_test/replicate_test/snapshot_test/type_test.py
@@ -1,7 +1,12 @@
 """zfs.replicate.snapshot.type tests."""
 
+from typing import Tuple
+
+from hypothesis import given
+
 from zfs.replicate.filesystem.type import filesystem
 from zfs.replicate.snapshot.type import Snapshot
+from zfs_test.replicate_test.snapshot_test.strategies import REBASED_SNAPSHOTS
 
 
 class TestSnapshotEq:
@@ -29,3 +34,25 @@ class TestSnapshotEq:
             timestamp=0,
         )
         assert local == remote
+
+
+class TestSnapshotHash:
+    """``Snapshot.__hash__`` collapses the fields ``__eq__`` is free to differ on."""
+
+    @given(REBASED_SNAPSHOTS)
+    def test_ignores_filesystem(self, rebased: Tuple[Snapshot, Snapshot]) -> None:
+        """A remote rebased under another dataset hashes as its local origin; see #502."""
+        local, remote = rebased
+        assert hash(local) == hash(remote)
+
+    @given(REBASED_SNAPSHOTS)
+    def test_set_membership(self, rebased: Tuple[Snapshot, Snapshot]) -> None:
+        """A set holding a local snapshot contains its rebased remote; see #502."""
+        local, remote = rebased
+        assert remote in {local}
+
+    def test_ignores_previous(self) -> None:
+        """A snapshot hashes as one differing only in previous; see #502."""
+        zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
+        previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
+        assert hash(zero) == hash(previous)

--- a/zfs_test/replicate_test/snapshot_test/type_test.py
+++ b/zfs_test/replicate_test/snapshot_test/type_test.py
@@ -37,7 +37,7 @@ class TestSnapshotEq:
 
 
 class TestSnapshotHash:
-    """``Snapshot.__hash__`` collapses the fields ``__eq__`` is free to differ on."""
+    """``Snapshot.__hash__`` holds equal Snapshots to one hash."""
 
     @given(REBASED_SNAPSHOTS)
     def test_ignores_filesystem(self, rebased: Tuple[Snapshot, Snapshot]) -> None:
@@ -52,7 +52,7 @@ class TestSnapshotHash:
         assert remote in {local}
 
     def test_ignores_previous(self) -> None:
-        """A snapshot hashes as one differing only in previous; see #502."""
+        """Two snapshots differing only in previous share a hash; see #502."""
         zero = Snapshot(filesystem=filesystem(""), name="", previous=None, timestamp=0)
         previous = Snapshot(filesystem=filesystem(""), name="", previous=zero, timestamp=0)
         assert hash(zero) == hash(previous)


### PR DESCRIPTION
## Summary

A `Snapshot` in a `set` or as a dict key now behaves the way `==` says it
should. Equality matches filesystem names by slash-aligned suffix, so a local
snapshot matches its remote counterpart, but the frozen dataclass hashed the
raw fields and those equal instances hashed differently. `Snapshot._key` now
names the `(name, timestamp)` pair equality compares exactly, and both `__eq__`
and `__hash__` read it.

Keeping the suffix equality was the question #502 left open: `task/generate.py`
depends on it, and #439 tightened it rather than dropping it.

Closes #502.

## Gotchas

- Suffix equality is not transitive (`pool/data` equals `data` equals
  `other/data`, while `pool/data` and `other/data` do not), so set *dedup*
  still turns on insertion order. Agreeing hashes fix lookup, nothing more.
- `__eq__` still raises `NotImplementedError` where Python's protocol asks for
  the `NotImplemented` singleton. Out of scope here, filed as #694.
- No production code hashes a `Snapshot` yet, since `venn` compares with `in`
  over lists. The new tests are the only thing exercising this.

## Test plan

- Reverted `snapshot/type.py` to master with the new tests in place: all three
  `TestSnapshotHash` cases fail. Restored: 82 pass.
