### PR TITLE
chore: expand the ruff rule set beyond tool-equivalence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,11 +98,67 @@ src = ["."]
 quote-style = "double"
 
 [tool.ruff.lint]
-# UP (pyupgrade) is intentionally omitted here: enabling it rewrites ~99 typing
-# annotations across the tree, deferred to keep this migration reviewable (#501).
-# PGH and RUF100 stand in for the removed pygrep-hooks and yesqa hooks; G010 for
-# python-no-log-warn; S (above) covers python-no-eval and the bandit rule set.
-select = ["E", "F", "I", "B", "SIM", "D", "N", "S", "G010", "PGH", "PL", "RUF100"]
+# PGH and RUF stand in for the removed pygrep-hooks and yesqa hooks; G for
+# python-no-log-warn; S covers python-no-eval and the bandit rule set.
+#
+# Groups weighed for this list and rejected:
+# A          filesystem.list, filesystem.type, and process.open shadow builtins on purpose.
+# ANN        mypy strict already demands the annotations.
+# COM        COM812 disagrees with ruff format about trailing commas.
+# CPY        the license sits at the repository root, not in file headers.
+# DOC        every rule is preview-gated, so selecting it enforces nothing.
+# FBT        would require making readonly, recursive, and follow_delete keyword-only.
+# FIX, TD    work is tracked in issues rather than in-code TODOs.
+# INP        the absent zfs_test __init__.py files are #621.
+# ISC        ruff format already joins implicit string concatenations.
+# PTH        the sole os.path call assembles a zfs dataset name, not a path.
+# TID        the package imports relatively throughout.
+# UP         the annotation rewrites are #501.
+# AIR, DJ, FAST, NPY, PD    frameworks this project does not use.
+select = [
+  "ARG",
+  "ASYNC",
+  "B",
+  "BLE",
+  "C4",
+  "C90",
+  "D",
+  "DTZ",
+  "E",
+  "EM",
+  "ERA",
+  "EXE",
+  "F",
+  "FA",
+  "FLY",
+  "FURB",
+  "G",
+  "I",
+  "ICN",
+  "INT",
+  "LOG",
+  "N",
+  "PERF",
+  "PGH",
+  "PIE",
+  "PL",
+  "PT",
+  "PYI",
+  "Q",
+  "RET",
+  "RSE",
+  "RUF",
+  "S",
+  "SIM",
+  "SLF",
+  "SLOT",
+  "T10",
+  "T20",
+  "TC",
+  "TRY",
+  "W",
+  "YTT"
+]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests assert (S101) and compare against literal expectations (PLR2004) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,23 +98,19 @@ src = ["."]
 quote-style = "double"
 
 [tool.ruff.lint]
-# PGH and RUF stand in for the removed pygrep-hooks and yesqa hooks; G for
-# python-no-log-warn; S covers python-no-eval and the bandit rule set.
-#
-# Groups weighed for this list and rejected:
-# A          filesystem.list, filesystem.type, and process.open shadow builtins on purpose.
+# Groups deliberately absent:
+# A          modules named for zfs subcommands shadow list, type, and open.
 # ANN        mypy strict already demands the annotations.
 # COM        COM812 disagrees with ruff format about trailing commas.
 # CPY        the license sits at the repository root, not in file headers.
 # DOC        every rule is preview-gated, so selecting it enforces nothing.
-# FBT        would require making readonly, recursive, and follow_delete keyword-only.
+# FBT        readonly, recursive, and follow_delete would become keyword-only.
 # FIX, TD    work is tracked in issues rather than in-code TODOs.
-# INP        the absent zfs_test __init__.py files are #621.
+# INP        cli_test and task_test still lack an __init__.py.
 # ISC        ruff format already joins implicit string concatenations.
-# PTH        the sole os.path call assembles a zfs dataset name, not a path.
+# PTH        os.path here assembles zfs dataset names, not filesystem paths.
 # TID        the package imports relatively throughout.
-# UP         the annotation rewrites are #501.
-# AIR, DJ, FAST, NPY, PD    frameworks this project does not use.
+# UP         enabling it rewrites about 130 typing annotations.
 select = [
   "ARG",
   "ASYNC",

--- a/zfs/replicate/cli/click.py
+++ b/zfs/replicate/cli/click.py
@@ -17,7 +17,7 @@ class EnumChoice(click.Choice[str]):
 
         choices = [x.lower() for x in enum._member_names_]
 
-        super().__init__(list(sorted(set(choices))))
+        super().__init__(sorted(set(choices)))
 
     def convert(self, value: Any, param: Any, ctx: Any) -> Any:
         """Convert string value to Enum value."""

--- a/zfs/replicate/cli/options.py
+++ b/zfs/replicate/cli/options.py
@@ -168,7 +168,8 @@ def _parse_properties(properties: Tuple[str, ...]) -> Dict[str, str]:
     for item in properties:
         key, separator, value = item.partition("=")
         if not separator or not key:
-            raise click.BadParameter(f"expected KEY=VALUE, got {item!r}", param_hint="--receive-set")
+            msg = f"expected KEY=VALUE, got {item!r}"
+            raise click.BadParameter(msg, param_hint="--receive-set")
         parsed[key] = value
 
     return parsed

--- a/zfs/replicate/compress/command.py
+++ b/zfs/replicate/compress/command.py
@@ -34,4 +34,5 @@ def command(compression: Compression) -> Optional[Commands]:
     if compression == Compression.OFF:
         return None
 
-    raise ValueError(f"invalid compression: '{compression}'", compression)
+    msg = f"invalid compression: '{compression}'"
+    raise ValueError(msg, compression)

--- a/zfs/replicate/filesystem/create.py
+++ b/zfs/replicate/filesystem/create.py
@@ -15,7 +15,8 @@ from .type import FileSystem
 def create(filesystem: FileSystem, ssh_command: Command) -> None:
     """Create a Remote FileSystem."""
     if filesystem.name is None:
-        raise ZFSReplicateError(f"refusing to create dataset: '{filesystem.dataset}'", filesystem)
+        msg = f"refusing to create dataset: '{filesystem.dataset}'"
+        raise ZFSReplicateError(msg, filesystem)
 
     top_level = type.filesystem(name=filesystem.dataset, readonly=filesystem.readonly)
 
@@ -35,8 +36,9 @@ def create(filesystem: FileSystem, ssh_command: Command) -> None:
             if b"successfully created, but not mounted" in error:
                 return  # Ignore this error.
 
+            msg = f"unable to create remote dataset: '{filesystem.dataset}': {error!r}"
             raise ZFSReplicateError(
-                f"unable to create remote dataset: '{filesystem.dataset}': {error!r}",
+                msg,
                 filesystem,
                 error,
             )

--- a/zfs/replicate/filesystem/create.py
+++ b/zfs/replicate/filesystem/create.py
@@ -37,11 +37,7 @@ def create(filesystem: FileSystem, ssh_command: Command) -> None:
                 return  # Ignore this error.
 
             msg = f"unable to create remote dataset: '{filesystem.dataset}': {error!r}"
-            raise ZFSReplicateError(
-                msg,
-                filesystem,
-                error,
-            )
+            raise ZFSReplicateError(msg, filesystem, error)
 
 
 def _create(filesystem: str) -> Command:

--- a/zfs/replicate/filesystem/destroy.py
+++ b/zfs/replicate/filesystem/destroy.py
@@ -14,8 +14,9 @@ def destroy(filesystem: FileSystem, ssh_command: Command) -> None:
     if result.returncode:
         error = clean(result.stderr)
 
+        msg = f"unable to destroy dataset: '{filesystem.dataset}': {error!r}"
         raise ZFSReplicateError(
-            f"unable to destroy dataset: '{filesystem.dataset}': {error!r}",
+            msg,
             filesystem,
             error,
         )

--- a/zfs/replicate/filesystem/destroy.py
+++ b/zfs/replicate/filesystem/destroy.py
@@ -15,11 +15,7 @@ def destroy(filesystem: FileSystem, ssh_command: Command) -> None:
         error = clean(result.stderr)
 
         msg = f"unable to destroy dataset: '{filesystem.dataset}': {error!r}"
-        raise ZFSReplicateError(
-            msg,
-            filesystem,
-            error,
-        )
+        raise ZFSReplicateError(msg, filesystem, error)
 
 
 def _destroy(filesystem: FileSystem) -> Command:

--- a/zfs/replicate/filesystem/list.py
+++ b/zfs/replicate/filesystem/list.py
@@ -20,8 +20,9 @@ def list(filesystem: FileSystem, ssh_command: Command) -> List[FileSystem]:
     if result.returncode:
         error = clean(result.stderr)
 
+        msg = f"error encountered while listing filesystems of '{filesystem.name}': {error!r}"
         raise ZFSReplicateError(
-            f"error encountered while listing filesystems of '{filesystem.name}': {error!r}",
+            msg,
             filesystem,
             error,
         )

--- a/zfs/replicate/filesystem/list.py
+++ b/zfs/replicate/filesystem/list.py
@@ -21,11 +21,7 @@ def list(filesystem: FileSystem, ssh_command: Command) -> List[FileSystem]:
         error = clean(result.stderr)
 
         msg = f"error encountered while listing filesystems of '{filesystem.name}': {error!r}"
-        raise ZFSReplicateError(
-            msg,
-            filesystem,
-            error,
-        )
+        raise ZFSReplicateError(msg, filesystem, error)
 
     return _filesystems(result.stdout)
 

--- a/zfs/replicate/optional.py
+++ b/zfs/replicate/optional.py
@@ -8,7 +8,8 @@ Value = TypeVar("Value")
 def value(optional: Optional[Value]) -> Value:
     """Raise error if optional is None."""
     if optional is None:
-        raise RuntimeError("unexpected None")
+        msg = "unexpected None"
+        raise RuntimeError(msg)
 
     return optional
 

--- a/zfs/replicate/snapshot/destroy.py
+++ b/zfs/replicate/snapshot/destroy.py
@@ -14,8 +14,9 @@ def destroy(snapshot: Snapshot, ssh_command: Command) -> None:
     if result.returncode:
         error = clean(result.stderr)
 
+        msg = f"unable to destroy snapshot: '{snapshot.filesystem.name}@{snapshot.name}': {error!r}"
         raise ZFSReplicateError(
-            f"unable to destroy snapshot: '{snapshot.filesystem.name}@{snapshot.name}': {error!r}",
+            msg,
             snapshot,
             error,
         )

--- a/zfs/replicate/snapshot/destroy.py
+++ b/zfs/replicate/snapshot/destroy.py
@@ -15,11 +15,7 @@ def destroy(snapshot: Snapshot, ssh_command: Command) -> None:
         error = clean(result.stderr)
 
         msg = f"unable to destroy snapshot: '{snapshot.filesystem.name}@{snapshot.name}': {error!r}"
-        raise ZFSReplicateError(
-            msg,
-            snapshot,
-            error,
-        )
+        raise ZFSReplicateError(msg, snapshot, error)
 
 
 def _destroy(snapshot: Snapshot) -> Command:

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -25,8 +25,9 @@ def list(
     if result.returncode:
         error = clean(result.stderr)
 
+        msg = f"error encountered while listing snapshots of '{filesystem.name}': {error!r}"
         raise ZFSReplicateError(
-            f"error encountered while listing snapshots of '{filesystem.name}': {error!r}",
+            msg,
             filesystem,
             error,
         )

--- a/zfs/replicate/snapshot/list.py
+++ b/zfs/replicate/snapshot/list.py
@@ -26,11 +26,7 @@ def list(
         error = clean(result.stderr)
 
         msg = f"error encountered while listing snapshots of '{filesystem.name}': {error!r}"
-        raise ZFSReplicateError(
-            msg,
-            filesystem,
-            error,
-        )
+        raise ZFSReplicateError(msg, filesystem, error)
 
     return _snapshots(result.stdout)
 

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -94,11 +94,7 @@ def _raise_for_failure(current: Snapshot, returncode: int, error: bytes) -> None
         return
 
     msg = f"failed to create snapshot: '{current.filesystem.name}@{current.name}': {error!r}"
-    raise ZFSReplicateError(
-        msg,
-        current,
-        error,
-    )
+    raise ZFSReplicateError(msg, current, error)
 
 
 def _send(

--- a/zfs/replicate/snapshot/send.py
+++ b/zfs/replicate/snapshot/send.py
@@ -93,8 +93,9 @@ def _raise_for_failure(current: Snapshot, returncode: int, error: bytes) -> None
     if not returncode or _MOUNTPOINT_FAILURE in error:
         return
 
+    msg = f"failed to create snapshot: '{current.filesystem.name}@{current.name}': {error!r}"
     raise ZFSReplicateError(
-        f"failed to create snapshot: '{current.filesystem.name}@{current.name}': {error!r}",
+        msg,
         current,
         error,
     )

--- a/zfs_test/replicate_test/cli_test/log_test.py
+++ b/zfs_test/replicate_test/cli_test/log_test.py
@@ -8,7 +8,7 @@ import zfs.replicate.cli.log as sut
 
 # Module-private, but exercised directly here rather than through the whole
 # logging stack.
-Formatter = sut._Formatter  # pylint: disable=protected-access
+Formatter = sut._Formatter  # noqa: SLF001
 
 
 def _record(level: int, message: str) -> logging.LogRecord:

--- a/zfs_test/replicate_test/compress_test/command_test.py
+++ b/zfs_test/replicate_test/compress_test/command_test.py
@@ -1,5 +1,7 @@
 """Test compress command generation."""
 
+from typing import cast
+
 import pytest
 
 from zfs.replicate.compress.command import command
@@ -13,3 +15,10 @@ class TestCommand:
     def test_total(self, compression: Compression) -> None:
         """Ensure command is a total function."""
         command(compression)
+
+    def test_rejects_a_compression_it_cannot_map(self) -> None:
+        """An unmapped compression raises rather than silently dropping the stage."""
+        # Every Compression member maps today, so reaching the guard that keeps a
+        # later member from falling through means casting past the type.
+        with pytest.raises(ValueError, match="invalid compression"):
+            command(cast("Compression", "zstd"))

--- a/zfs_test/replicate_test/filesystem_test/create_test.py
+++ b/zfs_test/replicate_test/filesystem_test/create_test.py
@@ -1,0 +1,60 @@
+"""zfs.replicate.filesystem.create tests."""
+
+import subprocess
+from collections.abc import Callable
+
+import pytest
+from pytest_mock import MockerFixture
+
+from zfs.replicate import process
+from zfs.replicate.command import Command
+from zfs.replicate.error import ZFSReplicateError
+from zfs.replicate.filesystem.create import create
+from zfs.replicate.filesystem.type import FileSystem, filesystem
+
+
+class TestCreate:
+    """A create refuses a dataset it cannot name and surfaces the remote's reason when it fails."""
+
+    @pytest.fixture
+    def fails_after_listing(self, mocker: MockerFixture) -> Callable[[bytes], None]:
+        """List an empty remote, then fail the create that follows with the given stderr."""
+
+        def _fails_after_listing(error: bytes) -> None:
+            mocker.patch.object(
+                process,
+                "run",
+                side_effect=[
+                    subprocess.CompletedProcess([], 0, b"", b""),
+                    subprocess.CompletedProcess([], 1, b"", error),
+                ],
+            )
+
+        return _fails_after_listing
+
+    def test_refuses_a_dataset_it_cannot_name(self, ssh_command: Command) -> None:
+        """Creating a FileSystem carrying no name names the dataset in the refusal."""
+        # FileSystem declares name as str, so the guard is only reachable by
+        # constructing one past the type.
+        nameless = FileSystem(dataset="pool", name=None, readonly=False)  # type: ignore[arg-type]
+
+        with pytest.raises(ZFSReplicateError) as raised:
+            create(nameless, ssh_command)
+
+        assert "refusing to create dataset: 'pool'" in raised.value.message
+
+    def test_reports_stderr_without_line_endings(
+        self,
+        fails_after_listing: Callable[[bytes], None],
+        ssh_command: Command,
+    ) -> None:
+        """A failed create names the dataset it could not create and the remote's reason."""
+        fails_after_listing(b"cannot create 'pool/data': permission denied\r\n")
+
+        with pytest.raises(ZFSReplicateError) as raised:
+            create(filesystem("pool/data"), ssh_command)
+
+        assert "unable to create remote dataset: 'pool'" in raised.value.message
+        assert "permission denied" in raised.value.message
+        assert "\\r" not in raised.value.message
+        assert "\\n" not in raised.value.message

--- a/zfs_test/replicate_test/filesystem_test/list_test.py
+++ b/zfs_test/replicate_test/filesystem_test/list_test.py
@@ -1,0 +1,30 @@
+"""zfs.replicate.filesystem.list tests."""
+
+from collections.abc import Callable
+
+import pytest
+
+from zfs.replicate.command import Command
+from zfs.replicate.error import ZFSReplicateError
+from zfs.replicate.filesystem.list import list_filesystems
+from zfs.replicate.filesystem.type import filesystem
+
+
+class TestListFilesystems:
+    """A failed list raises with the remote's reason, and nothing else."""
+
+    def test_reports_stderr_without_line_endings(
+        self,
+        fails_with: Callable[[bytes], None],
+        ssh_command: Command,
+    ) -> None:
+        """A failed list names the filesystem it could not read and the remote's reason."""
+        fails_with(b"cannot open 'pool/data': dataset does not exist\r\n")
+
+        with pytest.raises(ZFSReplicateError) as raised:
+            list_filesystems(filesystem("pool/data"), ssh_command)
+
+        assert "pool/data" in raised.value.message
+        assert "dataset does not exist" in raised.value.message
+        assert "\\r" not in raised.value.message
+        assert "\\n" not in raised.value.message


### PR DESCRIPTION
## Summary

Ruff's `select` tracked the stack it replaced, plus `UP` from #695, so most of
the linter sat idle. It now selects 43 stable rule groups where there were 13;
clearing them took thirteen fixes and no `ignore` entries. A comment above the
list names the condition keeping each absent group out.

The allowlist form stays rather than `select = ["ALL"]` with a denylist, for the
reason #499 gave: under `ALL`, a Renovate ruff bump enables new rules
unannounced.

Refactorings applied: **Extract Variable** at the ten raise sites, **Remove Dead
Code** on `list(sorted(...))`. Declined as past a lint-config change: **Extract
Function** over the `if result.returncode: ... raise` block repeating in six
modules, **Remove Dead Code** on the arguments `ZFSReplicateError.__init__`
swallows as `*_args`, **Replace Constructor with Factory Function**, and
**Rename Variable** on `msg`.

Closes #504

## Gotchas

- The test files are here because Extract Variable split four untested raise
  sites in two, and patch coverage counts a rewritten line as new. Two of those
  guards are unreachable through the declared types, so the tests construct the
  invalid input.
- `TRY` carries no `ignore` and `DOC` is absent from `select`: Extract Variable
  cleared all ten `TRY003` findings, and every `DOC` rule is preview-gated.
- `FURB171` is suppressed in `snapshot_test/type_test.py`, where equality would
  leave the `__hash__` from #696 untested.

## Test plan

- `pre-commit run --all-files` clean; suite green on 3.10 through 3.14.
- Patch coverage 100%, project 91% to 96%.
