### PR TITLE
docs: record why docstrings stay on pep257

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,10 +107,8 @@ select = ["E", "F", "I", "B", "SIM", "D", "N", "S", "G010", "PGH", "PL", "RUF100
 "zfs_test/**" = ["PLR2004", "S101"]
 
 [tool.ruff.lint.pydocstyle]
-# Switching to google or numpy would add section markup, not enforcement: D417
-# only inspects an Args section that already exists, while PEP 257 asks for
-# argument, return, and raises documentation where applicable. Sections pay off
-# alongside a generated API reference, which this console script doesn't ship.
+# D203/D211 and D212/D213 are incompatible pairs; naming a convention settles
+# each one instead of leaving ruff to warn and choose.
 convention = "pep257"
 
 [tool.vulture]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ select = ["E", "F", "I", "B", "SIM", "D", "N", "S", "G010", "PGH", "PL", "RUF100
 "zfs_test/**" = ["PLR2004", "S101"]
 
 [tool.ruff.lint.pydocstyle]
+# Switching to google or numpy would add section markup, not enforcement: D417
+# only inspects an Args section that already exists, while PEP 257 asks for
+# argument, return, and raises documentation where applicable. Sections pay off
+# alongside a generated API reference, which this console script doesn't ship.
 convention = "pep257"
 
 [tool.vulture]


### PR DESCRIPTION
## Summary

zfs-replicate keeps `pep257`, and the choice is now recorded rather than inherited as the default #404 left unrevisited. Closes #505.

Switching to `google` or `numpy` would change nothing ruff enforces. `D417` is the only argument rule either convention adds, and it inspects an `Args:` section that already exists, so a missing section stays silent under all three. PEP 257 is still Active and already asks a docstring to document its arguments, return values, and exceptions where applicable; the markup is what it leaves open, and pinning that down pays off alongside a generated API reference this console script doesn't ship.

That reasoning lives in this body and in `d2c4386`'s message, not in `pyproject.toml`. What the file keeps is two lines on why the setting is explicit at all, since a comment recording what was weighed and declined is the pattern #622 moves into history.

## Gotchas

- The issue's premise, that the section `D` rules would flag the gaps, doesn't hold for ruff. `ruff rule D417` says it "only checks docstrings with an arguments (e.g. `Args`) section", so no convention setting makes a missing section an error. Forcing sections needs the preview pydoclint `DOC` rules, which report 37 findings against `zfs/` today.
- `c2dd6c0` rewrites the comment `d2c4386` added, so reading the two commits in sequence shows more churn than the branch contains. The net diff against master is two comment lines.

## Test plan

- Ran `ruff check --select D` over `zfs/` at the pinned 0.16.3 under each of `pep257`, `google`, and `numpy`: zero violations in every case.
- Probed a two-argument function whose docstring documents only the first parameter: `D417` under `google`, `D406`/`D407` under `numpy`, nothing under `pep257`. A plain one-line docstring on the same function drew nothing under any of the three.
- Checked the surviving comment's claim with `ruff check --select D --isolated`: with no convention set, ruff reports D203/D211 and D212/D213 as incompatible and ignores one of each pair itself.
- `pre-commit run --all-files` passed.
