### PR TITLE
ci: publish to PyPI over OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,17 @@ jobs:
 
   pypi:
     name: Publish to PyPI
+    # A separate build keeps `id-token: write` out of scope while the build
+    # backend and its dependencies run.
     needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    # PyPI pins the Trusted Publisher it accepts to repo + workflow file +
-    # environment, so the OIDC token this job mints is only valid from here.
+    # PyPI matches the Trusted Publisher against repo, workflow filename, and
+    # environment. Renaming this file or the environment stops publishing
+    # until the publisher on PyPI matches again.
     environment: pypi
     permissions:
-      # The build runs in a job of its own so that the token minted here is
-      # never in scope while the build backend and its dependencies execute.
-      # Nothing is checked out, so `contents` stays out of the block.
+      # This job checks nothing out, so `contents` is deliberately absent.
       id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,26 +13,39 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  build:
+    name: Build the distribution
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/setup-poetry
+        with:
+          python-version: "3.x"
+      - name: poetry build
+        run: poetry build
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
   pypi:
     name: Publish to PyPI
+    needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     # PyPI pins the Trusted Publisher it accepts to repo + workflow file +
     # environment, so the OIDC token this job mints is only valid from here.
     environment: pypi
     permissions:
-      contents: read
+      # The build runs in a job of its own so that the token minted here is
+      # never in scope while the build backend and its dependencies execute.
+      # Nothing is checked out, so `contents` stays out of the block.
       id-token: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: install poetry
-        run: pipx install 'poetry<3'
-      - name: setup python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          python-version: "3.x"
-          cache: poetry
-      - name: poetry build
-        run: poetry build
+          name: dist
+          path: dist/
       - name: publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # PyPI pins the Trusted Publisher it accepts to repo + workflow file +
+    # environment, so the OIDC token this job mints is only valid from here.
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: install poetry
@@ -28,5 +34,5 @@ jobs:
           cache: poetry
       - name: poetry build
         run: poetry build
-      - name: poetry publish
-        run: poetry publish  --username __token__ --password=${{ secrets.PYPI_API_TOKEN }}
+      - name: publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Summary

Releases publish to PyPI without a long-lived `PYPI_API_TOKEN`.
`pypa/gh-action-pypi-publish` trades a GitHub OIDC token for one PyPI mints
for this repo, workflow, and environment, and emits PEP 740 provenance
attestations by default.

Two Fowler moves shape the result. *Split Phase* puts build and publish in
separate jobs joined by a `dist/` artifact, so `id-token: write` is never in
scope while the build backend runs; *Replace Inline Code with Function Call*
points the build at `.github/actions/setup-poetry`. Declined *Extract
Function* — a reusable workflow shared with `ci.yml`'s build job would carry
two common lines across two call sites — and *Rename Function* on the step
names, since the repo names steps after the command they run.

Refs #412; the remaining criteria are environment and secret changes outside
this repo.

## Gotchas

- The `pypi` environment is ungated:
  `gh api repos/:owner/:repo/environments/pypi` returns
  `"protection_rules": []`. #412 wants @alunduil as a required reviewer, but
  alunduil/alunduil-infrastructure#436 applied `environments = { pypi = {} }`,
  so it never landed.
- `PYPI_API_TOKEN` is still set and now unused. It comes out after the first
  successful OIDC release, not before.
- Nothing here exercises the publish path; it needs a real
  `release: published` event. That covers the claim that a same-run
  `download-artifact` works without `contents: read`, which follows PyPA's
  documented example rather than anything run here.
